### PR TITLE
link JT studies to the main TT index & define shorthand terms in prelude text

### DIFF
--- a/docs/modular/teletype/JFTT1.md
+++ b/docs/modular/teletype/JFTT1.md
@@ -5,9 +5,9 @@ permalink: /docs/modular/teletype/jt-1/
 
 ## Whimsical Prelude
 
-*monome's Teletype excites us. Writing simple scripts away from a computer; executing tiny morsels of musical composition. Just Type is a suggestion for how these ideas can be extended & deeply integrated with the elements of synthesis.*
+*monome's Teletype excites us. Writing simple scripts away from a computer; executing tiny morsels of musical composition. Just Type is a suggestion for how these ideas can be extended & deeply integrated with the elements of synthesis, using our Just Friends module.*
 
-*At its most basic, JT is a set of invisible patch cords. Type a command to create a trigger on your desired channel, in parallel with IRL voltages in JF's TRIGGER ins. RUN mode & voltage can be set directly, not needing a dummy cable or negative-offset capable voltage source.*
+*At its most basic, Just Type (JT) is a set of invisible patch cords. Type a command to create a trigger on your desired channel, in parallel with IRL voltages in Just Friends (JF)'s TRIGGER ins. RUN mode & voltage can be set directly, not needing a dummy cable or negative-offset capable voltage source.*
 
 *More than a cloaking device, Just Type extends the base functionality of JF into more complex territory. Use Teletype's `N` notation to easily transpose JF in 12-tone musical increments. Every output can be driven with a varying velocity, adding subtlety and movement to sequences. Even the INTONE relationship can be altered away from the default harmonic structure and instead taken in more experimental directions.*
 

--- a/docs/modular/teletype/index.md
+++ b/docs/modular/teletype/index.md
@@ -47,6 +47,8 @@ The basics of Teletype are quick to learn. The tutorials will get you started an
 
 * [Teletype Manual](/docs/modular/teletype/manual) - full manual, also available as a [pdf](manual.pdf)
 
+* [Just Type Studies](/docs/modular/teletype/jt-1) - a guided series of tutorials on integrating Teletype with Just Friends
+
 * [PDF command reference](TT_commands_2.1.pdf)
 * [PDF key reference](TT_keys_card_1.3.pdf)
 * [PDF scene recall sheet](TT_scene_RECALL_sheet.pdf)


### PR DESCRIPTION
link Just Type studies below the Teletype Studies listed in the TT index page, and explicitly define the shorthand naming conventions (JT, JF, Just Type, Just Friends) in the Whimsical Prelude text.