### PR TITLE
Copy pass for 1.6.0 docs #1.

### DIFF
--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -285,7 +285,9 @@ The glide view screen allows the user to slew the currently playing note into th
 
 ![](images/grid_KR_Glide.png)
 
-### 
+### Quick track muting
+
+Holding the *loop* modifer and pressing a track button will mute it; pressing again will unmute.
 
 ### Scale
 
@@ -394,6 +396,12 @@ To read a preset, press the position to select, and then press again to read.
 To write a preset, press and hold the position to write to.
 
 A "glyph" can be drawn in the right 8x8 quadrant as a visual cue as to what the preset is all about. This will be displayed when presets are selected for reading.
+
+### Teletype Clocking
+
+A channel of Kria can be set to be clocked from the Teletype command `KR.CLK x` (see below).
+
+To do so, hold down the pattern key, and `TODO DO SOMETHING`
 
 
 ## Meadowphysics (Grid)
@@ -734,6 +742,11 @@ KR.L.ST x y     return loop start of track x parameter y
 KR.L.LEN x y z  set length to z for track x parameter y
 KR.L.LEN x y    return loop length of track x parameter y
 KR.RES x y      set position to loop start for track x parameter y
+KR.CV x         current CV value of output x
+KR.MUTE x y     set the mute of track x to y (where y=1 is muted, y=0 is not.) if x is 0, set all				mutes to state y
+KR.TMUTE x      toggle mute for Kria track x, where x is 1-4. If x is 0, toggle all.
+			   toggle will _invert current state_.
+KR.CLK x        send to clock track x (or to all tracks if x==0) IF track is enabled to be clocked				 by Teletype (see above)
 ```
 
 ### Meadowphysics
@@ -747,6 +760,7 @@ MP.PERIOD x     set internal clock period to x
 MP.PERIOD       return current internal clock period
 MP.OFF x        stop channel x (0 = all)
 MP.RES x        reset channel x (0 = all) (also used as "start")
+MP.CV x 	    get current CV value of output x
 ```
 
 ### Levels

--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -220,7 +220,9 @@ The main grid view uses the bottom row for navigation, which are dimly lit into 
 
 ### Parameters
 
-Each *track* has four parameters *Trigger, Note, Octave,* and *Duration*. These parameters work together to form the sequence loop.
+Each *track* has four parameters *Trigger, Note, Octave,* and *Duration*. These parameters work together to form the sequence loop. 
+
+Select a parameter to adjust by pressing its key in the bottom row of the grid.
 
 A *note* will occur only when a *trigger* is set. This note will be the pitch specified by *note* in *octave* of a specified *duration*.
 
@@ -228,44 +230,7 @@ The *trigger* view shows all four tracks at once, whereas all other parameter vi
 
 The *duration* view has downward sliders (lower is longer) and a master duration multiplier at the top.
 
-#### Parameter extensions
-
-Many of the parameter views have sub pages that extend or augment their functionality. To enter into each sub page, switch to the parameter using buttons 5-8, then tap the parameter button again. When you are in the parameter extension page, the parameter button will blink, to assist with navigation.
-
-All of the subpages have their own probability, clock division and loop controls, allowing for some very complex phrasing to be built.
-
-* *Trigger* view becomes *Trigger Ratcheting*
-* *Note* view becomes *Alternate Note*
-* *Octave* view becomes *Glide*
-* *Duration* does not currently have a sub page
-
-
-##### Trigger Ratcheting
-The *trigger* view sub page is where you can control the amount of ratcheting per trigger.
-
-To enter the ratcheting page, press the trigger parameter button a second time when you are in the trigger view.
-
-Ratcheting uses rows 3-6 to determine the number of sub triggers that will fire for each trigger column. Selecting row 6 will cause no extra triggers to fire for that step. Selecting row 5 causes 1 extra trigger to fire, effectively turning an 8th note into two 16th notes. Row 4 will cause 2 extra triggers, for a total of 3, turning the single trigger into a triplet. Finally row 3 will cause 3 extra triggers to fire, turning an 8th note into 4 32nd notes.
-
-![](images\grid_KR_triggerRatcheting.png)
-
-
-
-##### Alternate Note
-The *note* view sub page allows you to effectively create a second note sequence for the track.
-
-Entering the alternate note page works the same as the ratcheting page. In the main note page press the note button a second time to enter the note page.
-
-The alternate note parameter screen is functionally identical to the main note screen, with its own probability, clock, division, and loop. Both note pages are additive. When 2 notes land on top of each other their notes are added and then mapped to the current scale. Changing the modifiers on these screens can allow for very complex interaction between set notes.
-
-##### Glide
-The *octave* views sub page supports up to 120 milliseconds of glide time between trigged notes.
-
-Like the other parameter extensions, you enter the glide page by tapping the octave button a second time, while in the main octave view.
-
-The glide view screen allows the user to slew the currently playing note into the next triggered note, this is controlled by setting a slider on each step column. Row 7 has a slew of 0ms, effectively a pass through. from here up each row increases the slew time to the note in the current column. Row 6 is 20ms row 5 is 40ms all the way to 120ms in row 1.
-
-![](images\grid_KR_Glide.png)
+There are also 'sub-pages' for more advanced extensions to each of these main parameters; see "**extended parameters**" for details.
 
 ### Modifiers
 
@@ -276,6 +241,51 @@ The *time* view shows the current clock divider.
 The *probability* view is a per-step probability for each parameter. There are four levels which specify likelihood of execution by percentage: 100, 75, 50, and 0. By default all are at 100%. 0% serves as a step mute of the specified parameter.
 
 Loops and time dividers are per parameter, per track, and so the phasing of parameters a fundamental feature of Kria.
+
+### Extended parameters
+
+Many of the parameter views have "sub-pages" that extend or augment their functionality. To enter into each sub-page, switch to the parameter using keys 6-9, then tap the parameter key again. When you are in the sub-page for a parameter, its paramater key will be blinking. Press the parameter again to return to the main parameter view.
+
+| Parameter | Extended Parameter |
+| --------- | ------------------ |
+| Trigger   | Trigger Ratcheting |
+| Note      | "Alternate Note"   |
+| Octave    | Glide              |
+| Duration  | *none*             |
+
+Just like the primary parameter pages, each of the extended parameter subpages have their own probability, clock division and loop controls. This allows for some very complex phrasing to be built.
+
+#### Trigger Ratcheting
+
+*Trigger ratcheting* allows multiple, regularly-spaced gates to be emitted for a single trigger in the grid.
+
+To enter the ratcheting page, press the trigger parameter key a second time when you are in the trigger view. The trigger parameter key will blink.
+
+Ratcheting uses rows 3-6 to determine the number of sub-triggers that will fire for each trigger column. Selecting row 6 will cause no extra triggers to fire for that step. Selecting row 5 causes 1 extra trigger to fire, effectively turning an 8th note into two 16th notes. Row 4 will cause 2 extra triggers, for a total of 3, turning the single trigger into a triplet. Finally row 3 will cause 3 extra triggers to fire - effectively turning an 8th note into 4 32nd notes.
+
+![](images/grid_KR_triggerRatcheting.png)
+
+
+
+#### Alternate Note
+
+*Alternate note* effectively allows a second note sequence to be specified for a track.
+
+To enter the alternate note page, press the note parameter key a second time when you are in the note view. The note parameter key will blink.
+
+The alternate note parameter screen is functionally identical to the main note screen, with its own probability, clock, division, and loop. Both note pages are additive. When 2 notes land on top of each other their notes are added and then mapped to the current scale. Changing the modifiers on these screens can allow for very complex interaction between set notes.
+
+#### Glide
+
+*Glide* allows up to 120ms of glide time to be added between triggered notes.
+
+To enter the glide page, press the octave parameter key a second time when you are in the octave view. The octave parameter key will blink.
+
+The glide view screen allows the user to slew the currently playing note into the next triggered note. This is controlled by setting a slider on each step column. Row 7 has a slew of 0ms, effectively a pass through. from here up each row increases the slew time to the note in the current column. Row 6 is 20ms row 5 is 40ms all the way to 120ms in row 1.
+
+![](images/grid_KR_Glide.png)
+
+### 
 
 ### Scale
 

--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -211,7 +211,7 @@ Four tracks of sequencers. Each track outputs to its respective CV/TR pair as pi
 The main grid view uses the bottom row for navigation, which are dimly lit into blocks and highlight the current setting:
 
  * 1-4: Track
- * 5-9: Trigger, Note, Octave, Duration
+ * 6-9: Trigger, Note, Octave, Duration
  * 11-13: MODIFIERS: Loop, Time, Probability
  * 15: Scale
  * 16: Pattern

--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -303,6 +303,8 @@ For example, a whole tone scale (2 semitones per note) would be constructed by s
 
 Scales are shared between Kria and Meadowphysics, and are saved to flash whenever a preset of either is saved.
 
+The top-left four keys on the *scale* page are used to toggle Teletype clocking for a given channel; see below for more details.
+
 ### Patterns
 
 Patterns are shown along the top row, with 16 available total. Push a pattern key momentarily to load that pattern. *Hold* a pattern key to store the current pattern into it; it will pulse when the pattern is stored. Remember that loading an 'empty' pattern will effectively clear the current pattern.
@@ -401,7 +403,7 @@ A "glyph" can be drawn in the right 8x8 quadrant as a visual cue as to what the 
 
 A channel of Kria can be set to be clocked from the Teletype command `KR.CLK x` (see below).
 
-To do so, hold down the pattern key, and `TODO DO SOMETHING`
+To do so, hold down the *scale* key; the four leftmost keys in the top row will enable or disable Teletype clocking for the relevant channel.
 
 
 ## Meadowphysics (Grid)
@@ -744,9 +746,9 @@ KR.L.LEN x y    return loop length of track x parameter y
 KR.RES x y      set position to loop start for track x parameter y
 KR.CV x         current CV value of output x
 KR.MUTE x y     set the mute of track x to y (where y=1 is muted, y=0 is not.) if x is 0, set all				mutes to state y
-KR.TMUTE x      toggle mute for Kria track x, where x is 1-4. If x is 0, toggle all.
+KR.TMUTE x      toggle mute for Kria track x (0 = all)
 			   toggle will _invert current state_.
-KR.CLK x        send to clock track x (or to all tracks if x==0) IF track is enabled to be clocked				 by Teletype (see above)
+KR.CLK x        send to clock track x (0 == all) IF track is enabled to be clocked							   by Teletype (see above)
 ```
 
 ### Meadowphysics

--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -273,7 +273,13 @@ Ratcheting uses rows 3-6 to determine the number of sub-triggers that will fire 
 
 To enter the alternate note page, press the note parameter key a second time when you are in the note view. The note parameter key will blink.
 
-The alternate note parameter screen is functionally identical to the main note screen, with its own probability, clock, division, and loop. Both note pages are additive. When 2 notes land on top of each other their notes are added and then mapped to the current scale. Changing the modifiers on these screens can allow for very complex interaction between set notes.
+The alternate note parameter screen is functionally identical to the main note screen, with its own probability, clock, division, and loop. 
+
+Both note pages - main and alternate - are *additive*. When a note from each screen is played simultaneously, the indices of the keys within the scale are added together, and then mapped to the current scale. 
+
+For example: if a note from each page is triggered and both are in the bottom row of the scale - "note 0" - then the CV output is for `0 + 0 = 0`, ie, note zero, the root of the scale. If the current main note is the 4th  key up (index *3* of the scale) and the alt-note is the 3rd key up (index *2*). This step in the sequence will output `3+2 = 5` index 5 of the scale, ie, the 6th note.
+
+The possibilities for alternate note become particularly interesting if you alter its probability or clock division, or if its loop points take it out of phase with the main note.
 
 #### Glide
 

--- a/docs/modular/ansible/index.md
+++ b/docs/modular/ansible/index.md
@@ -409,7 +409,7 @@ A "glyph" can be drawn in the right 8x8 quadrant as a visual cue as to what the 
 
 A channel of Kria can be set to be clocked from the Teletype command `KR.CLK x` (see below).
 
-To do so, hold down the *scale* key; the four leftmost keys in the top row will enable or disable Teletype clocking for the relevant channel.
+To do so, press the *scale* key to enter scale view. The four leftmost keys in the top row will enable or disable Teletype clocking for the relevant channel. When a channel is clocked by Teletype, it no longer responds to the master clock (set either internally or by an external clock connected to the `In 1`).
 
 
 ## Meadowphysics (Grid)


### PR DESCRIPTION

So: a few changes I've made, which are up for discussion:

* house style seems to be passive voice, so I've removed 'you' where
appropriate
* house style also calls keys on the grid 'keys' or, wherever possible,
just refers to them by the function they are performing ("press
'octave'; the octave key will light"). So I've removed 'button' and made
appropriate changes
* for entirely personal reasons I found 'extended parameters' more
appropriate than 'parameter extensions'
* I've moved some things around. More specifically: the "parameter
extensions" documentation mentions loop/probability/division _before_
we've explained it in the main documentation! So: key, 'basic'
parameters are explained; we mention that there are also extended
parameters, see later; then modifiers are explained; then the extended
parameters section
* replaced h5s with h4s, h5 renders tiny in the default stylesheet
* sub-page, not sub page
* Took a pass at explaining each mode in a single sentence. Also removed
some of the narrative style (referencing previous paras) because
a use-case for documentation is jumping straight to a para. So there's
a bit more repetition, but I think that's OK for technical writing.
* added TODOs for the Teletype commands