### PR TITLE
Have positionrand cover all steps.

### DIFF
--- a/docs/norns/study-3.md
+++ b/docs/norns/study-3.md
@@ -470,7 +470,7 @@ function top() note = 120 end
 function rand() note = math.random(80) + 40 end
 function metrofast() counter.time = 0.125 end
 function metroslow() counter.time = 0.25 end
-function positionrand() position = math.random(8) end
+function positionrand() position = math.random(STEPS) end
 
 act = {inc, dec, bottom, top, rand, metrofast, metroslow, positionrand}
 COMMANDS = 8


### PR DESCRIPTION
This wasn’t causing an error or warning, I was just a little confused at first as to why `#` would only jump to the first half of the sequence.