### PR TITLE
just type studies: typo fixes

### DIFF
--- a/docs/modular/teletype/JFTT1.md
+++ b/docs/modular/teletype/JFTT1.md
@@ -88,7 +88,7 @@ Just Type simply ignores this hardware normalization because every channel *is* 
 
 ## Enemy of the state
 
-*sustain* is the only mode that will respond to (indeed, requires) a 'low' trigger. In *sustain*, every `JF.TR channel 1` command must have an accompanying `JF.TR channel 0` to release the envleope.
+*sustain* is the only mode that will respond to (indeed, requires) a 'low' trigger. In *sustain*, every `JF.TR channel 1` command must have an accompanying `JF.TR channel 0` to release the envelope.
 
 Implementation is up to the synthesist, but here are some starting points:
 

--- a/docs/modular/teletype/JFTT3.md
+++ b/docs/modular/teletype/JFTT3.md
@@ -60,7 +60,7 @@ Just Friends is set to *sound/sustain* for *PLUME*. INTONE is turned fully CW. *
 
 The first script begins by cycling through a simple six note sequence. The cascading `JF.TUNE` modulations that follow provide unique translations and transpositions of the sequence. A semi-contrapuntal choir is born from only a few lines of code and three modules.
 
-`M` provides TRIGGERS to all channels, as well as a variable release (`DEL / M X: JF.TR 0 0`). Adjust `X` to taste or map it to the paramater knob.
+`M` provides TRIGGERS to all channels, as well as a variable release (`DEL / M X: JF.TR 0 0`). Adjust `X` to taste or map it to the parameter knob.
 
 Expansions on this scene could include RUN modulation through `JF.RUN state`, volume automation with `JF.VTR channel velocity`, or more adventurous tuning ratios.
 

--- a/docs/modular/teletype/JFTT5.md
+++ b/docs/modular/teletype/JFTT5.md
@@ -28,21 +28,21 @@ The timebase for *Geode* can be established through two different uses of one co
 
 (These movie title references are almost over.)
 
-Cut from the same cloth as *Synthesis*, *Geode* also utilizes `JF.VOX` and `JF.NOTE` in its own tongue. Instead of lush grumbles and glassy tones, *Geode* speaks in streams of rhythmic envelopes on a named channel, dutifully repeating at a rhythm defined by a divison of the clock's measure.
+Cut from the same cloth as *Synthesis*, *Geode* also utilizes `JF.VOX` and `JF.NOTE` in its own tongue. Instead of lush grumbles and glassy tones, *Geode* speaks in streams of rhythmic envelopes on a named channel, dutifully repeating at a rhythm defined by a division of the clock's measure.
 
-`JF.VOX channel divison repeats`
+`JF.VOX channel division repeats`
 
 Create a stream at the specified channel, of defined rhythm and duration.
 
 - *channel*: select the channel (`1`-`6`) to assign this stream, `0` sets all
-- *divison*: set the rhythmic division of a measure
+- *division*: set the rhythmic division of a measure
 - *repeats*: set the number of repeats in the stream, `-1` repeats indefinitely
 
 `JF.NOTE division repeats`
 
 Dynamic allocation. Assigns the rhythmic stream to the oldest unused channel, or if all channels are busy, the longest running channel.
 
-- *division*: set the rhythmic divison of a measure
+- *division*: set the rhythmic division of a measure
 - *repeats*: set the number of repeats in the stream, `-1` repeats indefinitely
 
 ## Flow
@@ -51,7 +51,7 @@ Though streams use *division* to determine their rhythm, events can be queued an
 
 `JF.QT division`
 
-- *divison*: `1` to `32` sets the subdivision and activates quantization, `0` deactivates
+- *division*: `1` to `32` sets the subdivision and activates quantization, `0` deactivates
 
 Think of `JF.QT` as a performative glue rather than a rigid gridlock. It will slightly affect the timing and 'swing' of events. This is especially wonderful when executing scripts manually or with a fuzz-timed source.
 

--- a/docs/modular/teletype/JFTT6.md
+++ b/docs/modular/teletype/JFTT6.md
@@ -7,7 +7,7 @@ permalink: /docs/modular/teletype/jt-6/
 
 ## Less is more
 
-There's something fulfilling about digging in deep with smaller toolkits. Just Type allows for a wide range of styles and intentions -- from sprawling modulation to straightfoward composition.
+There's something fulfilling about digging in deep with smaller toolkits. Just Type allows for a wide range of styles and intentions -- from sprawling modulation to straightforward composition.
 
 The commands and examples covered in this series are simplified starting points, begging to be chained together toward complex goals. Interacting with Just Type through both hardware and software will open even more doors, but much can be explored through coding alone.
 


### PR DESCRIPTION
no content changes; only some typos in the JT study pages.