### PR TITLE
make http links explicit

### DIFF
--- a/docs/norns/script-reference.md
+++ b/docs/norns/script-reference.md
@@ -234,5 +234,5 @@ TODO
 
 ## further
 - [Norns Lua docs](https://monome.github.io/norns/doc/)
-- https://monome.org/docs/norns
-- https://github.com/monome/norns
+- [https://monome.org/docs/norns](https://monome.org/docs/norns)
+- [https://github.com/monome/norns](https://github.com/monome/norns)


### PR DESCRIPTION
dunno if there's a way to make jekyll smarter but currently these links aren't rendering on https://monome.org/docs/norns/script-reference/:

![image](https://user-images.githubusercontent.com/67586/55671021-23021100-5840-11e9-91aa-0ad131bb5584.png)

calling them out explicitly should do the trick.

/cc @tehn 
