### PR TITLE
norns: fix header

### DIFF
--- a/docs/norns/index.md
+++ b/docs/norns/index.md
@@ -382,6 +382,7 @@ cd 190409
 - Upon completion type `sudo shutdown now` to shut down.
 
 ## HELP
+
 ### ERROR: AUDIO ENGINE
 
 If norns shows `ERROR: AUDIO ENGINE` chances are there's a problem with duplicate SuperCollider classes.


### PR DESCRIPTION
No clue why this isn't working on the docs site, my markdown preview locally works fine. I'm just guessing that this will fix it.

It seems this repo is missing Jekyll's `_config.yml` so I can't reproduce the settings as they are used on the docs site locally.