### PR TITLE
ansible firmware update procedure should use 0512 chip

### DIFF
--- a/docs/modular/update.md
+++ b/docs/modular/update.md
@@ -90,18 +90,18 @@ to backup your firmware, install [dfu-programmer](http://dfu-programmer.github.i
 
 once in bootloader mode, open a terminal and run:
 
-    dfu-programmer at32uc3b0256 read > firmware-name.hex
+    dfu-programmer at32uc3b0512 read > firmware-name.hex
 
 restart the module before you unplug the USB cable:
 
-    dfu-programmer at32uc3b0256 start
+    dfu-programmer at32uc3b0512 start
 
 you can restore the backed-up firmware any time by getting back into bootloader mode, opening a terminal in your backup's directory, and running:
 
 ```
-dfu-programmer at32uc3b0256 erase
-dfu-programmer at32uc3b0256 flash firmware-name.hex --suppress-bootloader-mem
-dfu-programmer at32uc3b0256 start
+dfu-programmer at32uc3b0512 erase
+dfu-programmer at32uc3b0512 flash firmware-name.hex --suppress-bootloader-mem
+dfu-programmer at32uc3b0512 start
 ```
 
 > note: these are the same commands that are run by the `update_firmware.command` script included in the official firmware releases.


### PR DESCRIPTION
At least recent revisions of the Ansible hardware use the `at32uc3b0512` chip, not the `at32uc3b0256`. Not sure if this was changed at some point and older Ansibles have an `0256`. Since the `0512` has more memory, as far as I can tell the existing procedure described in the docs will still work for reflashing firmware but the `read` command will not correctly back up presets from NVRAM.