### PR TITLE
norns: study 3: fixes arguments to params:add_control()

### DIFF
--- a/docs/norns/study-3.md
+++ b/docs/norns/study-3.md
@@ -280,10 +280,10 @@ note that we're using a new syntax style with curly brackets. this passes a tabl
 add more parameters with multiple lines of `params:add_number()`, but all parameters are not just basic numbers. there is a _control_ parameter that maps a "control" range (thing 0-100) to a specified min/max, with linear and exponential scaling. we use these frequently with engine parameters:
 
 ```
-params:add_control("cutoff",controlspec.new(50,5000,'exp',0,555,'hz'))
+params:add_control("cutoff","cutoff",controlspec.new(50,5000,'exp',0,555,'hz'))
 ```
 
-the second argument of the `params:add_control` function is a _control spec_. we use `controlspec.new()` to create a new spec with arguments:
+the third argument of the `params:add_control` function is a _control spec_. we use `controlspec.new()` to create a new spec with arguments:
 
 - min = 50
 - max = 5000


### PR DESCRIPTION
```lua
params:add_control("cutoff",controlspec.new(50,5000,'exp',0,555,'hz'))
```

If you paste this line of code as-is while following study 3, matron complains with the following message.

```
/home/we/norns/lua/core/screen.lua:130: bad argument #1 to 's_text' (string expected, got table)
stack traceback:
        [C]: in function 's_text'
        /home/we/norns/lua/core/screen.lua:130: in function 'core/screen.text'
        /home/we/norns/lua/core/menu.lua:579: in field 'redraw'
```

This change avoids that.