### PR TITLE
include() does not need .lua extension, throws error

### DIFF
--- a/docs/norns/script-reference.md
+++ b/docs/norns/script-reference.md
@@ -73,7 +73,7 @@ myscript/
 `myscript.lua` can include `somelib.lua` using:
 
 ```lua
-include("lib/somelib.lua")
+include("lib/somelib")
 ```
 
 ### third party libraries


### PR DESCRIPTION
Explained [here](https://llllllll.co/t/norns-scripting/14120/608)