### PR TITLE
Replace "begin" links with "setup".

### DIFF
--- a/docs/grid-studies/arduino/index.md
+++ b/docs/grid-studies/arduino/index.md
@@ -19,7 +19,7 @@ Be sure you have Arduino version 1.6.0 or later. **It is required.**
 
 Download Arduino: [arduino.cc](http://http://arduino.cc/en/Main/Software)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-arduino.zip](files/grid-studies-arduino.zip)
 

--- a/docs/grid-studies/max/index.md
+++ b/docs/grid-studies/max/index.md
@@ -17,7 +17,7 @@ This lesson assumes a basic understanding of the Max patching interface. If you'
 
 Download Max 7: [cycling74.com/downloads](https://cycling74.com/downloads/)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-max.zip](files/grid-studies-max.zip)
 

--- a/docs/grid-studies/nodejs/index.md
+++ b/docs/grid-studies/nodejs/index.md
@@ -23,7 +23,7 @@ If you're very new to node.js (or JavaScript) a few tutorials and introduction v
 
 Download Node.js: [nodejs.org](http://nodejs.org/)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-nodejs.zip](files/grid-studies-nodejs.zip)
 

--- a/docs/grid-studies/pd/index.md
+++ b/docs/grid-studies/pd/index.md
@@ -17,7 +17,7 @@ If you're new to Pd, spend a few moments with these introductory tutorials from 
 
 Download Pd Extended: [puredata.info/](http://puredata.info/downloads/pd-extended)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-pd.zip](files/grid-studies-pd.zip)
 

--- a/docs/grid-studies/processing/index.md
+++ b/docs/grid-studies/processing/index.md
@@ -15,7 +15,7 @@ If you're very new to Processing (or Java), it will be very beneficial to work t
 
 Download Processing: [processing.org](http://processing.org)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-processing.zip](files/grid-studies-processing.zip)
 

--- a/docs/grid-studies/sc/index.md
+++ b/docs/grid-studies/sc/index.md
@@ -17,7 +17,7 @@ If you're very new to SuperCollider, it will be very beneficial to work through 
 
 Download SuperCollider: [supercollider.sourceforge.net](http://supercollider.sourceforge.net/)
 
-Download the monome installer: [monome.org/docs/begin](http://monome.org/docs/begin)
+Download the monome installer: [monome.org/docs/setup](http://monome.org/docs/setup)
 
 Download the code examples here: [files/grid-studies-sc.zip](files/grid-studies-sc.zip)
 


### PR DESCRIPTION
A number of the studies pages have links to https://monome.org/docs/begin. This page, however, simply redirects to the homepage. This PR replaces all of those links to point to monome.org/docs/setup.