### PR TITLE
crow: Use relative links for docs

### DIFF
--- a/crow/faq.md
+++ b/crow/faq.md
@@ -77,7 +77,7 @@ Or on norns: `crow.output[1].volts = 3.33`
 
 This command tells crow “please emit 3.33 volts from your first output”. There are currently a few things that know how to talk to crow (norns, druid, and the Max/M4L toolkit), but this list will hopefully grow.
 
-[Documentation of this syntax](https://monome.org/docs/crow/reference/).
+[Documentation of this syntax](../reference).
 
 Using one of these tools, you could:
 
@@ -96,7 +96,7 @@ Search `tags:crow+norns` at llllllll.co (or [click here](https://llllllll.co/sea
 
 #### writing norns + crow scripts
 
-Visit [crow studies](https://monome.org/docs/crow/norns/) to learn how to integrate crow within scripts on norns.
+Visit [crow studies](../norns) to learn how to integrate crow within scripts on norns.
 
 ### druid
 
@@ -106,7 +106,7 @@ Visit [bowery](https://github.com/monome/bowery), a collection of druid scripts 
 
 #### writing crow scripts in druid
 
-Visit the [scripting reference](https://monome.org/docs/crow/scripting/) to learn how to use Lua to livecode and create standalone scripts for crow.
+Visit the [scripting reference](../scripting) to learn how to use Lua to livecode and create standalone scripts for crow.
 
 #### how large a script can I run or store on crow in standalone?
 

--- a/crow/index.md
+++ b/crow/index.md
@@ -56,12 +56,12 @@ For the code-curious, see the implementation [on github](https://github.com/mono
 
 While *First* is a compelling instrument on its own, crow collects all manner of objects: other Eurorack synthesizer modules, computers, and norns.
 
-We have trained crow to navigate the following landscapes, but you can also script your own flight patterns. Please feel free to peruse the [scripting tutorial](https://monome.org/docs/crow/scripting/) and crow's command [reference page](https://monome.org/docs/crow/reference/).
+We have trained crow to navigate the following landscapes, but you can also script your own flight patterns. Please feel free to peruse the [scripting tutorial](scripting) and crow's command [reference page](reference).
 
 ### norns
 
 - crow integrates seamlessly as a CV and [**ii**](/docs/modular/ii) interface
-- on October 1st 2019, we released an [**update**](https://monome.org/docs/norns/#update) that allows scripts to communicate with crow
+- on October 1st 2019, we released an [**update**](../norns/#update) that allows scripts to communicate with crow
 - [**community-made norns apps with crow integration**](https://llllllll.co/search?expanded=true&q=tags%3Acrow%2Bnorns%20order%3Alatest) on lines
 - want to script on your own? See the full [**crow studies**](norns) for a complete guide
 
@@ -94,7 +94,7 @@ See the [technical](technical) page for further details.
 
 ## Help
 
-Answers to frequently asked questions can be found in the [FAQ](https://monome.org/docs/crow/faq/).
+Answers to frequently asked questions can be found in the [FAQ](faq).
 
 Community discussion happens at [llllllll.co](https://llllllll.co). Come say hello!
 

--- a/crow/norns.md
+++ b/crow/norns.md
@@ -9,11 +9,11 @@ permalink: /crow/norns/
 
 Crow serves as a CV and ii interface for norns.
 
-It may be helpful to first explore the [norns studies](https://monome.org/docs/norns/study-1/) to provide context for how to integrate crow's new functionality.
+It may be helpful to first explore the [norns studies](../../norns/study-1) to provide context for how to integrate crow's new functionality.
 
 Download: [github.com/monome/crow-studies](https://github.com/monome/crow-studies)
 
-(Note: be sure your norns is [updated](https://monome.org/docs/norns/#update) to version 190920 or later.)
+(Note: be sure your norns is [updated](../../norns/#update) to version 190920 or later.)
 
 Crow will automatically be detected and interfaced upon connection to norns. Presently only a single crow is supported.
 


### PR DESCRIPTION
Fixes the link to the reference page as used on the scripting page

This way stuff keeps working if it's moved around + it works locally.

P.S. I think all the permalinks at the top of every page can be removed, the directory structure and filenames already dictate the name.
And if you use `permalink: pretty` as a setting pages get redirected from `docs/crow/faq` to `docs/crow/faq/` which is the way the permalinks are currently hardcoded.