### PR TITLE
Bootloader clarity & formatting of technical & updated list of crow commands

### DIFF
--- a/crow/technical.md
+++ b/crow/technical.md
@@ -7,63 +7,50 @@ permalink: /crow/technical/
 
 ## Calibration
 
-Crow has an in-built calibration mechanism to allow the inputs and outputs to
-accurately follow and output values. This functionality is primarily for use with
-volt-per-octave signals, though of course this accuracy can be used for any number
-of other purposes!
+Crow has an in-built calibration mechanism to allow the inputs and outputs to accurately follow and output values. This functionality is primarily for use with volt-per-octave signals, though of course this accuracy can be used for any number of other purposes!
 
-All modules come pre-calibrated from the factory, so you'll likely never need to
-think about this, but just in case, recalibration and data inspection is allowed.
+All modules come pre-calibrated from the factory, so you'll likely never need to think about this, but just in case, recalibration and data inspection is allowed.
 
 ### cal.test()
 
 The `cal.test()` function causes crow to re-run the calibration process.
 
 **You must remove all patch cables from the jacks for this process to work correctly!**
-Calling `test` without any arguments runs the calibration as per normal, while
-running `test('default')` will not run the calibration process, but instead return
-to default values, in case you're having problems with the calibration process.
+
+Calling `test` without any arguments runs the calibration as per normal, while running `test('default')` will not run the calibration process, but instead return to default values, in case you're having problems with the calibration process.
 
 ### cal.print()
 
-This helper function is just for debugging purposes. Calling it will simply dump
-a list of values showing the scaling & translation of voltages that were measured
-during the calibration process. If you're really curious try resetting to the defaults
-then printing, followed by a `test()` and `print()` to see the difference.
-
+This helper function is just for debugging purposes. Calling it will simply dump a list of values showing the scaling & translation of voltages that were measured during the calibration process. If you're really curious try resetting to the defaults then printing, followed by a `test()` and `print()` to see the difference.
 
 ## Environment Commands
 
-The below commands should be integrated into a host environment as macros or
-commands. In particular, the user shouldn't need to worry about typing them
-explicitly. norns should provide higher-level functions that send these low-level
-commands & split up larger code pieces automatically.
+The below commands should be integrated into a host environment as macros or commands. In particular, the user shouldn't need to worry about typing them explicitly. norns should provide higher-level functions that send these low-level commands & split up larger code pieces automatically.
 
-The following commands are parsed directly from usb, so should work even if the lua
-environment has crashed. nb: start/end script won't work correctly if the env is
-down though. Use `^^clearscript` first.
+The following commands are parsed directly from usb, so should work even if the Lua environment has crashed. nb: start/execute/write-script won't work correctly if the env is down though. Use `^^clearscript` first.
 
-nb: only the first char after the `^^` symbol matters, so the host can
-simply send a 3 char command (eg `^^s`) for brevity & speed
+nb: only the first char after the `^^` symbol matters, so the host can simply send a 3 char command (eg `^^s`) for brevity & speed
 
-- `^^startscript`: sets crow to reception mode. following code will be saved to a buffer
-- `^^endscript`: buffered code will be error-checked, eval'd, and written to flash. crow returns to repl mode.
-- `^^clearscript`: clears onboard flash without touching lua. use this if your script is crashing crow.
-- `^^printscript`: requests crow to print the current user script saved in flash over usb to the host. prints a warning if no user script exists.
+- `^^startscript`: sets crow to reception mode. following code will be saved to a buffer.
+- `^^executescript`: crow will restart. buffered code will be error-checked and run immediately.
+- `^^writescript`: crow will restart. buffered code will be error-checked, written to flash, then run.
+- `^^clearscript`: clears a saved user script. use this if your script is crashing crow. or you want a clean slate.
+- `^^First`: restarts crow and sets `First` as the default script to run on boot, and runs it.
+- `^^printscript`: requests crow to print the current user script saved in flash over usb to the host. prints a note if no user script exists or First is running.
 - `^^bootloader`: jump directly to the bootloader.
-- `^^reset` / `^^restart`: reboots crow (not just lua env). nb: causes usb connection to be reset.
-- `^^kill`: restarts the lua environment
+- `^^reset`: reboots crow (not just Lua env). nb: causes usb connection to be reset.
+- `^^kill`: restarts the lua environment but doesn't run the user script.
 - `^^identity`: returns serial number.
 - `^^version`: returns current firmware version.
 
 
 ### Recovering from an unresponsive state
 
-It's entirely possible to upload crow scripts that will make crow unresponsive
-and require clearing of the on-board script.
+It's entirely possible to upload crow scripts that will make crow unresponsive and require clearing of the on-board script.
 
-The gentlest way to deal with this situation is to send the `^^clearscript`
-command over usb, which may be followed by `^^reset`
+The gentlest way to deal with this situation is to send the `^^clearscript` command over usb
 
-- Druid: `^^c` then `^^r`
-- Norns: `crow.clear()` then `crow.reset()`
+- Druid: `^^c`
+- Norns: `crow.clear()`
+
+If crow stays unresponsive, or doesn't appear to be connected to your host, you'll need to enter the bootloader and run `erase_userscript.sh`.

--- a/crow/update.md
+++ b/crow/update.md
@@ -24,7 +24,7 @@ Download the `crow-vx.x.x.zip` file.
 
 ## Activate bootloader
 
-With the crow connected to druid (or a similar utility) you can enter the bootloader with a `^^b` message, which will instantly reset the module and take you to the bootloader.
+With the crow connected to druid (or a similar utility) you can enter the bootloader with a `^^b` message, which will instantly reset the module and take you to the bootloader. `druid` will start printing `<lost connection>` at which point crow is ready to bootload, and you should quit `druid` with `q`.
 
 
 ## Forcing the bootloader
@@ -41,7 +41,7 @@ to bridge the pins while powering on the case.
 
 ## Flashing the update
 
-Execute the `flash.sh` command which is included in the release .zip file. The actual firmware file that is uploaded is `crow.bin`.
+From the Terminal (make sure you've quit `druid`), execute the `flash.sh` command which is included in the release .zip file. The actual firmware file that is uploaded is `crow.bin`.
 
 For example if your file was extracted to `~/Downloads/crow-1.1.0` type this on the command line:
 


### PR DESCRIPTION
1. Makes it very clear that `dfu-util` is separate from `druid` and that you need to quit out of `druid` after receiving the `<lost connection>` message.
2. Formatted the technical page (previously i had added manual line-breaks in paragraphs for 80char terminal.
3. Updated / corrected the list of `^^` crow commands in technical.