### PR TITLE
clarify scripting tutorial and reference

### DIFF
--- a/crow/faq.md
+++ b/crow/faq.md
@@ -102,11 +102,11 @@ Visit [crow studies](../norns) to learn how to integrate crow within scripts on 
 
 #### finding community scripts
 
-Visit [bowery](https://github.com/monome/bowery), a collection of druid scripts which hosts community contributions.
+Visit *stage one* of the [scripting tutorial](scripting) to learn how to upload scripts; to find new scripts to upload, visit [bowery](https://github.com/monome/bowery), a collection of druid scripts which hosts community contributions.
 
 #### writing crow scripts in druid
 
-Visit the [scripting reference](../scripting) to learn how to use Lua to livecode and create standalone scripts for crow.
+Visit *stage one* and *stage two* of the [scripting tutorial](../scripting) to learn how to use Lua to livecode and create standalone scripts for crow.  The [scripting reference](reference) provides additional documentation of the scripting language.
 
 #### how large a script can I run or store on crow in standalone?
 

--- a/crow/faq.md
+++ b/crow/faq.md
@@ -102,11 +102,11 @@ Visit [crow studies](../norns) to learn how to integrate crow within scripts on 
 
 #### finding community scripts
 
-Visit *stage one* of the [scripting tutorial](scripting) to learn how to upload scripts; to find new scripts to upload, visit [bowery](https://github.com/monome/bowery), a collection of druid scripts which hosts community contributions.
+Visit *stage one* of the [scripting tutorial](../scripting) to learn how to upload scripts; to find new scripts to upload, visit [bowery](https://github.com/monome/bowery), a collection of druid scripts which hosts community contributions.
 
 #### writing crow scripts in druid
 
-Visit *stage one* and *stage two* of the [scripting tutorial](../scripting) to learn how to use Lua to livecode and create standalone scripts for crow.  The [scripting reference](reference) provides additional documentation of the scripting language.
+Visit *stage two* and *stage three* of the [scripting tutorial](../scripting) to learn how to use Lua to livecode and create standalone scripts for crow.  The [scripting reference](../reference) provides additional documentation of the scripting language.
 
 #### how large a script can I run or store on crow in standalone?
 

--- a/crow/index.md
+++ b/crow/index.md
@@ -56,7 +56,7 @@ For the code-curious, see the implementation [on github](https://github.com/mono
 
 While *First* is a compelling instrument on its own, crow collects all manner of objects: other Eurorack synthesizer modules, computers, and norns.
 
-We have trained crow to navigate the following landscapes, but you can also script your own flight patterns. Please feel free to peruse the [scripting tutorial](scripting) and crow's command [reference page](reference).
+We have trained crow to navigate the following landscapes:
 
 ### norns
 
@@ -69,7 +69,8 @@ We have trained crow to navigate the following landscapes, but you can also scri
 
 - you can use your terminal to access [**druid**](https://github.com/monome/druid), a small utility for communicating with crow
 - druid helps you engage crow in realtime interaction and also upload full scripts (coded in Lua), providing an interactive platform for designing new patterns in a modular synth
-- want to see what others have scripted? visit [**bowery**](https://github.com/monome/bowery), the druid script collection
+- want to see what others have scripted? visit [**bowery**](https://github.com/monome/bowery), the druid script collection, and complete *stage one* of the [**scripting tutorial**](scripting) to learn how to upload scripts
+- learn to map your own flight paths with *stage two* and *stage three* of the [**scripting tutorial**](scripting)
 
 ### computer + Max 8 / Max for (Ableton) Live
 
@@ -77,6 +78,11 @@ We have trained crow to navigate the following landscapes, but you can also scri
 - we have created Max for Live devices to integrate crow with Live, including: Live-synced clocks, MIDI-to-v/8, CC-to-Voltage, LFO's, executing Lua code directly in Live, parameter mapping your crow scripts, and triggering Lua chunks with MIDI
 - using the [crow] object in Max 8, create your own Live-controllable devices or standalone utilities
 - visit the [**Max and Max for Live repo on GitHub**](https://github.com/monome/crow-max)
+
+### birdsong (reference)
+
+- if you are writing or modifying norn apps, standalone scripts, or Max patches, you will want to become fluent in the language of the birds...
+- visit the [**scripting reference**](reference) to become a crow whisperer 
 
 ## Updates
 


### PR DESCRIPTION
a lot of people have missed the scripting reference page; this aims to remedy that.

it also makes it clearer where to find instructions for uploading other scripts.