### PR TITLE
add redirects for pages previously under /docs/modular/

### DIFF
--- a/ansible/cycles.md
+++ b/ansible/cycles.md
@@ -3,6 +3,7 @@ layout: default
 title: cycles
 parent: ansible
 nav_order: 4
+redirect_from: /modular/ansible/cycles/
 ---
 
 ## Cycles (Ansible + Arc)

--- a/ansible/earthsea.md
+++ b/ansible/earthsea.md
@@ -3,6 +3,7 @@ layout: default
 title: earthsea
 parent: ansible
 nav_order: 3
+redirect_from: /modular/ansible/earthsea/
 ---
 
 ## Earthsea (Ansible + Grid)

--- a/ansible/index.md
+++ b/ansible/index.md
@@ -4,6 +4,7 @@ title: ansible
 nav_order: 6
 has_children: true
 has_toc: false
+redirect_from: /modular/ansible/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/182119406?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/ansible/kria.md
+++ b/ansible/kria.md
@@ -3,6 +3,7 @@ layout: default
 title: kria
 parent: ansible
 nav_order: 1
+redirect_from: /modular/ansible/kria/
 ---
 
 ## Kria (Ansible + Grid)

--- a/ansible/levels.md
+++ b/ansible/levels.md
@@ -3,6 +3,7 @@ layout: default
 title: levels
 parent: ansible
 nav_order: 5
+redirect_from: /modular/ansible/levels/
 ---
 
 ## Levels (Ansible + Arc)

--- a/ansible/meadowphysics.md
+++ b/ansible/meadowphysics.md
@@ -3,6 +3,7 @@ layout: default
 title: meadowphysics
 parent: ansible
 nav_order: 2
+redirect_from: /modular/ansible/meadowphysics/
 ---
 
 ## Meadowphysics (Ansible + Grid)

--- a/ansible/midi.md
+++ b/ansible/midi.md
@@ -3,6 +3,7 @@ layout: default
 title: midi
 parent: ansible
 nav_order: 6
+redirect_from: /modular/ansible/midi/
 ---
 
 ## MIDI/voice

--- a/ansible/teletype.md
+++ b/ansible/teletype.md
@@ -3,6 +3,7 @@ layout: default
 title: teletype
 parent: ansible
 nav_order: 7
+redirect_from: /modular/ansible/teletype/
 ---
 
 ## Ansible + Teletype

--- a/earthsea/index.md
+++ b/earthsea/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: earthsea
 nav_order: 9
+redirect_from: /modular/earthsea/
 ---
 
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/113231441?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>

--- a/meadowphysics/index.md
+++ b/meadowphysics/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: meadowphysics
 nav_order: 8
+redirect_from: /modular/meadowphysics/
 ---
 
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/146731772?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>

--- a/switch/index.md
+++ b/switch/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: switch
 nav_exclude: true
+redirect_from: /modular/switch/
 ---
 
 # Switch
@@ -54,6 +55,3 @@ Flip the switch on the panel downward to **B** and you will see the grid update 
 While designed for switching focus between modules, the switch can also be used to alternate between a grid-enabled module and computer. This can help avoid awkward hot-swapping when a computer is out of reach or inaccessible.
 
 We have found much success using a computer for processing the audio output from a Eurorack synthesizer with a grid-based application like [mlrv](https://github.com/trentgill/mlrv2/releases/latest), while switching to monome modules in the case. With this setup it's usually easiest using Switch to change context between computer (**A**) and modular (**B**), and then hot-swapping the **B** cable to different modules.
-
-
-

--- a/teletype/JFTT1.md
+++ b/teletype/JFTT1.md
@@ -4,6 +4,7 @@ parent: teletype
 title: just type studies
 nav_order: 4
 permalink: /teletype/jt-1/
+redirect_from: /modular/teletype/jt-1/
 ---
 
 ## Whimsical Prelude

--- a/teletype/JFTT2.md
+++ b/teletype/JFTT2.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/jt-2/
+redirect_from: /modular/teletype/jt-2/
 ---
 
 <div class="vid"><iframe width="860" height="484" src="https://www.youtube.com/embed/SczDW9WMDTA?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>

--- a/teletype/JFTT3.md
+++ b/teletype/JFTT3.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/jt-3/
+redirect_from: /modular/teletype/jt-3/
 ---
 
 <div class="vid"><iframe width="860" height="484" src="https://www.youtube.com/embed/PQ4xUgWUlQQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>

--- a/teletype/JFTT4.md
+++ b/teletype/JFTT4.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/jt-4/
+redirect_from: /modular/teletype/jt-4/
 ---
 
 <div class="vid"><iframe width="860" height="484" src="https://www.youtube.com/embed/5IoiERamfb8?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>

--- a/teletype/JFTT5.md
+++ b/teletype/JFTT5.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/jt-5/
+redirect_from: /modular/teletype/jt-5/
 ---
 
 <div class="vid"><iframe width="860" height="484" src="https://www.youtube.com/embed/PF7gS-sXw_k?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>

--- a/teletype/JFTT6.md
+++ b/teletype/JFTT6.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/jt-6/
+redirect_from: /modular/teletype/jt-6/
 ---
 
 <div class="vid"><iframe width="860" height="484" src="https://www.youtube.com/embed/cFkbs5Q57fc?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>

--- a/teletype/scenes-10.md
+++ b/teletype/scenes-10.md
@@ -3,6 +3,7 @@ layout: default
 title: scenes
 parent: teletype
 nav_order: 3
+redirect_from: /modular/teletype/scenes-10
 ---
 
 # Teletype 1.0 Scenes

--- a/teletype/tts1.md
+++ b/teletype/tts1.md
@@ -4,6 +4,7 @@ title: studies
 parent: teletype
 nav_order: 2
 permalink: /teletype/studies-1/
+redirect_from: /modular/teletype/studies-1/
 ---
 
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/135080129?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>

--- a/teletype/tts2.md
+++ b/teletype/tts2.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-2/
+redirect_from: /modular/teletype/studies-2/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/135609254?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/teletype/tts3.md
+++ b/teletype/tts3.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-3/
+redirect_from: /modular/teletype/studies-3/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/136304442?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/teletype/tts4.md
+++ b/teletype/tts4.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-4/
+redirect_from: /modular/teletype/studies-4/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/137005129?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/teletype/tts5.md
+++ b/teletype/tts5.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-5/
+redirect_from: /modular/teletype/studies-5/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/137408958?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/teletype/tts6.md
+++ b/teletype/tts6.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-6/
+redirect_from: /modular/teletype/studies-6/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/139376775?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/teletype/tts7.md
+++ b/teletype/tts7.md
@@ -2,6 +2,7 @@
 layout: default
 nav_exclude: true
 permalink: /teletype/studies-7/
+redirect_from: /modular/teletype/studies-7/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/139730521?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 

--- a/walk/index.md
+++ b/walk/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: walk
 nav_order: 10
+redirect_from: /modular/walk/
 ---
 
 # Walk

--- a/whitewhale/index.md
+++ b/whitewhale/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: whitewhale
 nav_order: 7
+redirect_from: /modular/whitewhale/
 ---
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/104881064?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 
@@ -386,4 +387,3 @@ The bottom row is intended for use with standard CV inputs rather than tuned osc
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/105408057?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/105408747?color=ff7700&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
-


### PR DESCRIPTION
Seems that /docs/modular/teletype was redirecting properly but links like /docs/modular/whitewhale, /docs/modular/ansible, /docs/modular/teletype/jt-1 were not. I haven't found any indication that there's a way to do this besides adding redirects to every page individually.