### PR TITLE
TT studies: point to manual for key reference, mention help mode

### DIFF
--- a/teletype/index.md
+++ b/teletype/index.md
@@ -67,6 +67,8 @@ The basics of Teletype are quick to learn. The tutorials will get you started an
 
 * [Default scenes](scenes-1.0/)
 
+You can also access in-module help any time by using ALT-H to toggle help mode.
+
 ## Further
 
 Teletype is [open-source](https://github.com/monome/teletype). Since its initial release Teletype has grown an improved extensively thanks to various contributors including @sam, @scanner_darkly, and @sliderule. Additionally the documentation has undergone full reworking.

--- a/teletype/tts1.md
+++ b/teletype/tts1.md
@@ -165,9 +165,9 @@ TR.TIME x y     set pulse time of trigger x to y (ms)
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 ## Teletype Studies Continued
 

--- a/teletype/tts2.md
+++ b/teletype/tts2.md
@@ -250,9 +250,9 @@ M.RESET         reset counter for metro script
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 ## Teletype Studies Continued
 

--- a/teletype/tts3.md
+++ b/teletype/tts3.md
@@ -275,9 +275,9 @@ DRUNK x         set DRUNK value to x
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 ## Teletype Studies Continued
 

--- a/teletype/tts4.md
+++ b/teletype/tts4.md
@@ -221,9 +221,9 @@ AVG x y         average x and y
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 
 ## Teletype Studies Continued

--- a/teletype/tts5.md
+++ b/teletype/tts5.md
@@ -258,9 +258,9 @@ P.END x         set loop end to x for working pattern
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 
 ## Teletype Studies Continued

--- a/teletype/tts6.md
+++ b/teletype/tts6.md
@@ -216,9 +216,9 @@ S.L             read only, size of stack
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 
 ## Teletype Studies Continued

--- a/teletype/tts7.md
+++ b/teletype/tts7.md
@@ -311,9 +311,9 @@ SCENE           load stored scene
 
 [Full Command Chart](../TT_commands_card.pdf)
 
-### Keys
+[Teletype Key Reference](../manual/#keys)
 
-[Teletype Key Chart](../TT_keys_card.pdf)
+You can also browse help within Teletype by using ALT-H to toggle help mode.
 
 
 ## Teletype Studies Continued


### PR DESCRIPTION
The end of each Teletype study currently links to [this](https://monome.org/docs/teletype/TT_commands_card.pdf) command card and [this](https://monome.org/docs/teletype/TT_keys_card.pdf) key reference. A more up-to-date PDF command reference might be [this](https://monome.org/docs/teletype/TT_commands_3.0.pdf) pandoc-generated one (which is also linked from the main Teletype page) but the content is not quite the same - the older card linked from the studies has some descriptions of Teletype scripting terminology and a little intro for each section. Leaving this unchanged for now.

However some of the key reference PDF no longer matches current versions of the firmware, notably:
* tilde shows variables in live mode, it no longer switches between live and tracker mode
* F1-F10 manually execute scripts, instead of CTRL+1 or WIN+1

This patch instead links to https://monome.org/docs/teletype/manual/#keys which is generated documentation from the Teletype repo and should stay a lot more up-to-date.

Additionally I sprinkled these "see also" sections with a mention of how to access Teletype's in-module help mode, since I have had multiple interactions with long-time users who didn't know it existed.

Spurred by [this](https://llllllll.co/t/teletype-workflow-basics-and-questions/12392/815) post.