### PR TITLE
teletype: update manual html for 3.2.0

### DIFF
--- a/teletype/manual/index.html
+++ b/teletype/manual/index.html
@@ -5,16 +5,16 @@
         <meta name="generator" content="pandoc">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-        
-        
-        
+
+
+
         <title></title>
 
-        
-        
+
+
                     <link href="data:text/css;charset=utf-8,%0Abody%20%7B%0Afont%2Dfamily%3A%20Roboto%2C%20sans%2Dserif%3B%0Afont%2Dsize%3A%2016px%3B%0Aline%2Dheight%3A%2026px%3B%0Acolor%3A%20%23443e3c%3B%0Abackground%2Dcolor%3A%20white%3B%0Adisplay%3A%20flex%3B%0Aflex%2Dwrap%3A%20wrap%3B%0Amargin%3A%200%3B%0Aheight%3A%20100%25%3B%0A%7D%0Aa%20%7B%0Acolor%3A%20%23409BDF%3B%0Atext%2Ddecoration%3A%20none%3B%0A%7D%0Aa%3Ahover%20%7B%0Atext%2Ddecoration%3A%20underline%3B%0A%7D%0Aa%2Eabsent%20%7B%0Acolor%3A%20%23cc0000%3B%0A%7D%0Aa%2Eanchor%20%7B%0Adisplay%3A%20block%3B%0Apadding%2Dleft%3A%2030px%3B%0Amargin%2Dleft%3A%20%2D30px%3B%0Acursor%3A%20pointer%3B%0Aposition%3A%20absolute%3B%0Atop%3A%200%3B%0Aleft%3A%200%3B%0Abottom%3A%200%3B%0A%7D%0Ah1%2C%0Ah2%2C%0Ah3%2C%0Ah4%2C%0Ah5%2C%0Ah6%20%7B%0Amargin%3A%2020px%200%2010px%3B%0Apadding%3A%200%3B%0Acolor%3A%20%23443e3c%3B%0Afont%2Dweight%3A%20700%3B%0A%2Dwebkit%2Dfont%2Dsmoothing%3A%20antialiased%3B%0Acursor%3A%20text%3B%0Aposition%3A%20relative%3B%0Adisplay%3A%20flex%3B%0Aalign%2Ditems%3A%20center%3B%0A%7D%0Ah1%3Ahover%20a%2Eanchor%2C%0Ah2%3Ahover%20a%2Eanchor%2C%0Ah3%3Ahover%20a%2Eanchor%2C%0Ah4%3Ahover%20a%2Eanchor%2C%0Ah5%3Ahover%20a%2Eanchor%2C%0Ah6%3Ahover%20a%2Eanchor%20%7B%0Atext%2Ddecoration%3A%20none%3B%0A%7D%0Ah1%20tt%2C%0Ah1%20code%2C%0Ah2%20tt%2C%0Ah2%20code%2C%0Ah3%20tt%2C%0Ah3%20code%2C%0Ah4%20tt%2C%0Ah4%20code%2C%0Ah5%20tt%2C%0Ah5%20code%2C%0Ah6%20tt%2C%0Ah6%20code%20%7B%0Afont%2Dsize%3A%20inherit%3B%0A%7D%0Ah1%20%7B%0Adisplay%3A%20block%3B%0Afont%2Dsize%3A%202em%3B%0Amargin%2Dblock%2Dstart%3A%200%2E67em%3B%0Amargin%2Dblock%2Dend%3A%200%2E67em%3B%0Amargin%2Dinline%2Dstart%3A%200px%3B%0Amargin%2Dinline%2Dend%3A%200px%3B%0A%7D%0Ah2%20%7B%0Adisplay%3A%20block%3B%0Afont%2Dsize%3A%201%2E5em%3B%0Amargin%2Dblock%2Dstart%3A%200%2E83em%3B%0Amargin%2Dblock%2Dend%3A%200%2E83em%3B%0Amargin%2Dinline%2Dstart%3A%200px%3B%0Amargin%2Dinline%2Dend%3A%200px%3B%0A%7D%0Ah3%20%7B%0Adisplay%3A%20block%3B%0Afont%2Dsize%3A%201%2E17em%3B%0Amargin%2Dblock%2Dstart%3A%201em%3B%0Amargin%2Dblock%2Dend%3A%201em%3B%0Amargin%2Dinline%2Dstart%3A%200px%3B%0Amargin%2Dinline%2Dend%3A%200px%3B%0A%7D%0Ah4%20%7B%0Adisplay%3A%20block%3B%0Amargin%2Dblock%2Dstart%3A%201%2E33em%3B%0Amargin%2Dblock%2Dend%3A%201%2E33em%3B%0Amargin%2Dinline%2Dstart%3A%200px%3B%0Amargin%2Dinline%2Dend%3A%200px%3B%0A%7D%0Ah5%20%7B%0Afont%2Dsize%3A%2014px%3B%0A%7D%0Ah6%20%7B%0Acolor%3A%20%23777777%3B%0Afont%2Dsize%3A%2014px%3B%0A%7D%0Ah1%2C%0Ah2%20%7B%0Amargin%2Dtop%3A%20100px%3B%0A%7D%0Ah1%3A%3Abefore%2C%0Ah2%3A%3Abefore%20%7B%20display%3A%20block%3B%20content%3A%20%22%20%22%3B%20margin%2Dtop%3A%20%2D95px%3B%20height%3A%2095px%3B%20visibility%3A%20hidden%3B%20pointer%2Devents%3A%20none%3B%0A%7D%0Ap%2C%0Ablockquote%2C%0Aul%2C%0Aol%2C%0Adl%2C%0Ali%2C%0Atable%2C%0Apre%20%7B%0Amargin%3A%2015px%200%3B%0A%7D%0Ahr%20%7B%0Aborder%3A%200%20none%3B%0Acolor%3A%20%23cccccc%3B%0Aheight%3A%204px%3B%0Apadding%3A%200%3B%0A%7D%0Abody%20%3E%20h2%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0Apadding%2Dtop%3A%200%3B%0A%7D%0Abody%20%3E%20h1%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0Apadding%2Dtop%3A%200%3B%0A%7D%0Abody%20%3E%20h1%3Afirst%2Dchild%20%2B%20h2%20%7B%0Amargin%2Dtop%3A%200%3B%0Apadding%2Dtop%3A%200%3B%0A%7D%0Abody%20%3E%20h3%3Afirst%2Dchild%2C%0Abody%20%3E%20h4%3Afirst%2Dchild%2C%0Abody%20%3E%20h5%3Afirst%2Dchild%2C%0Abody%20%3E%20h6%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0Apadding%2Dtop%3A%200%3B%0A%7D%0Aa%3Afirst%2Dchild%20h1%2C%0Aa%3Afirst%2Dchild%20h2%2C%0Aa%3Afirst%2Dchild%20h3%2C%0Aa%3Afirst%2Dchild%20h4%2C%0Aa%3Afirst%2Dchild%20h5%2C%0Aa%3Afirst%2Dchild%20h6%20%7B%0Amargin%2Dtop%3A%200%3B%0Apadding%2Dtop%3A%200%3B%0A%7D%0Ah1%20p%2C%0Ah2%20p%2C%0Ah3%20p%2C%0Ah4%20p%2C%0Ah5%20p%2C%0Ah6%20p%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Ali%20p%2Efirst%20%7B%0Adisplay%3A%20inline%2Dblock%3B%0A%7D%0Aul%2C%0Aol%20%7B%0Alist%2Dstyle%3A%20none%3B%0Apadding%3A%200%3B%0A%7D%0Aul%3Afirst%2Dchild%2C%0Aol%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Aul%3Alast%2Dchild%2C%0Aol%3Alast%2Dchild%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0Ablockquote%20%7B%0Aborder%2Dleft%3A%204px%20solid%20%23dddddd%3B%0Apadding%3A%200%2015px%3B%0Acolor%3A%20%23777777%3B%0A%7D%0Ablockquote%20%3E%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Ablockquote%20%3E%3Alast%2Dchild%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0Aimg%20%7B%0Amax%2Dwidth%3A%20100%25%3B%0A%7D%0Aspan%2Eframe%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0A%7D%0Aspan%2Eframe%20%3E%20span%20%7B%0Aborder%3A%201px%20solid%20%23dddddd%3B%0Adisplay%3A%20block%3B%0Afloat%3A%20left%3B%0Aoverflow%3A%20hidden%3B%0Amargin%3A%2013px%200%200%3B%0Apadding%3A%207px%3B%0Awidth%3A%20auto%3B%0A%7D%0Aspan%2Eframe%20span%20img%20%7B%0Adisplay%3A%20block%3B%0Afloat%3A%20left%3B%0A%7D%0Aspan%2Eframe%20span%20span%20%7B%0Aclear%3A%20both%3B%0Acolor%3A%20%23333333%3B%0Adisplay%3A%20block%3B%0Apadding%3A%205px%200%200%3B%0A%7D%0Aspan%2Ealign%2Dcenter%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0Aclear%3A%20both%3B%0A%7D%0Aspan%2Ealign%2Dcenter%20%3E%20span%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0Amargin%3A%2013px%20auto%200%3B%0Atext%2Dalign%3A%20center%3B%0A%7D%0Aspan%2Ealign%2Dcenter%20span%20img%20%7B%0Amargin%3A%200%20auto%3B%0Atext%2Dalign%3A%20center%3B%0A%7D%0Aspan%2Ealign%2Dright%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0Aclear%3A%20both%3B%0A%7D%0Aspan%2Ealign%2Dright%20%3E%20span%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0Amargin%3A%2013px%200%200%3B%0Atext%2Dalign%3A%20right%3B%0A%7D%0Aspan%2Ealign%2Dright%20span%20img%20%7B%0Amargin%3A%200%3B%0Atext%2Dalign%3A%20right%3B%0A%7D%0Aspan%2Efloat%2Dleft%20%7B%0Adisplay%3A%20block%3B%0Amargin%2Dright%3A%2013px%3B%0Aoverflow%3A%20hidden%3B%0Afloat%3A%20left%3B%0A%7D%0Aspan%2Efloat%2Dleft%20span%20%7B%0Amargin%3A%2013px%200%200%3B%0A%7D%0Aspan%2Efloat%2Dright%20%7B%0Adisplay%3A%20block%3B%0Amargin%2Dleft%3A%2013px%3B%0Aoverflow%3A%20hidden%3B%0Afloat%3A%20right%3B%0A%7D%0Aspan%2Efloat%2Dright%20%3E%20span%20%7B%0Adisplay%3A%20block%3B%0Aoverflow%3A%20hidden%3B%0Amargin%3A%2013px%20auto%200%3B%0Atext%2Dalign%3A%20right%3B%0A%7D%0Acode%2C%0Att%20%7B%0Afont%2Dfamily%3A%20monospace%2C%20monospace%3B%0Afont%2Dsize%3A%2016px%3B%0Abackground%2Dcolor%3A%20%23eeeceb%3B%0Acolor%3A%20%23443e3c%3B%0Apadding%3A%202px%206px%3B%0Amargin%3A%200px%203px%3B%0A%7D%0Apre%20code%20%7B%0Amargin%3A%200%3B%0Apadding%3A%200%3B%0Awhite%2Dspace%3A%20pre%2Dwrap%3B%0Aborder%3A%20none%3B%0Abackground%3A%20transparent%3B%0A%7D%0Apre%20%7B%0Afont%2Dsize%3A%2016px%3B%0Aline%2Dheight%3A%2026px%3B%0Abackground%2Dcolor%3A%20%23eeeceb%3B%0Apadding%3A%205px%205px%205px%2010px%3B%0A%7D%0Apre%20code%2C%0Apre%20tt%20%7B%0Abackground%2Dcolor%3A%20transparent%3B%0Aborder%3A%20none%3B%0A%7D%0A%0A%2EAlphaOpList%20table%20%7B%0Apadding%3A%200%3B%0Awidth%3A%20100%25%3B%0Atable%2Dlayout%3A%20fixed%3B%0Aborder%2Dspacing%3A%200px%3B%0Aborder%2Dcollapse%3A%20collapse%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20%7B%0Abackground%2Dcolor%3A%20white%3B%0Amargin%3A%200%3B%0Apadding%3A%200%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20th%20%7B%0Afont%2Dweight%3A%20bold%3B%0Aborder%2Dbottom%3A%201px%20solid%20black%3B%0Atext%2Dalign%3A%20left%3B%0Amargin%3A%200%3B%0Apadding%3A%206px%2013px%3B%0Aword%2Dbreak%3A%20break%2Dword%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20td%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23cccccc%3B%0Atext%2Dalign%3A%20left%3B%0Amargin%3A%200%3B%0Apadding%3A%206px%2013px%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20th%3Afirst%2Dchild%2C%0A%2EAlphaOpList%20table%20tr%20td%3Afirst%2Dchild%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20th%3Alast%2Dchild%2C%0A%2EAlphaOpList%20table%20tr%20td%3Alast%2Dchild%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20th%3Afirst%2Dchild%20%7B%0Afont%2Dweight%3A%20normal%3B%0Afont%2Dsize%3A%2014px%3B%0Afont%2Dstyle%3A%20italic%3B%0A%7D%0A%2EAlphaOpList%20table%20tr%20th%3Afirst%2Dchild%20code%20%7B%0Afont%2Dweight%3A%20bold%3B%0Afont%2Dsize%3A%2018px%3B%0Afont%2Dstyle%3A%20normal%3B%0A%7D%0A%2EAlphaOpList%20code%2C%0A%2EAlphaOpList%20tt%20%7B%0Abackground%2Dcolor%3A%20white%3B%0Apadding%3A%200%3B%0Amargin%3A%200%3B%0Awhite%2Dspace%3A%20pre%2Dwrap%3B%0A%7D%0A%2EOpList%20%7B%0Aborder%2Dbottom%3A%202px%20solid%20black%3B%0Apadding%2Dbottom%3A%2050px%3B%0Amargin%2Dbottom%3A%20100px%3B%0A%7D%0A%2EKeyList%20table%2C%0A%2EOpList%20table%20%7B%0Awidth%3A%20100%25%3B%0Adisplay%3A%20block%3B%0A%7D%0A%2EKeyList%20thead%2C%0A%2EOpList%20thead%20%7B%0Afont%2Dweight%3A%20bold%3B%0Awidth%3A%20100%25%3B%0Adisplay%3A%20block%3B%0A%7D%0A%2EKeyList%20tbody%2C%0A%2EOpList%20tbody%20%7B%0Adisplay%3A%20flex%3B%0Aflex%2Ddirection%3A%20column%3B%0Awidth%3A%20100%25%3B%0A%7D%0A%2EKeyList%20thead%20%3E%20tr%2C%0A%2EKeyList%20tr%2C%0A%2EOpList%20thead%20%3E%20tr%2C%0A%2EOpList%20tr%20%7B%0Adisplay%3A%20flex%3B%0Aflex%2Ddirection%3A%20column%3B%0Aborder%2Dbottom%3A%201px%20solid%20%23ccc%3B%0Apadding%3A%2020px%200%3B%0Atext%2Dalign%3A%20left%3B%0A%7D%0A%2EKeyList%20tbody%20tr%3Alast%2Dchild%2C%0A%2EOpList%20tbody%20tr%3Alast%2Dchild%20%7B%0Aborder%2Dbottom%3A%200%3B%0A%7D%0A%2EKeyList%20thead%20%3E%20tr%2C%0A%2EOpList%20thead%20%3E%20tr%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20black%3B%0A%7D%0A%2EKeyList%20th%20%3E%20code%2C%0A%2EKeyList%20td%20%3E%20strong%20%3E%20code%2C%0A%2EOpList%20th%20%3E%20code%2C%0A%2EOpList%20td%20%3E%20strong%20%3E%20code%20%7B%0Abackground%3A%20initial%3B%0Apadding%3A%200%3B%0Amargin%3A%200%3B%0A%7D%0A%2EKeyList%20th%2C%0A%2EKeylist%20td%2C%0A%2EOpList%20th%2C%0A%2EOpList%20td%20%7B%0Amax%2Dwidth%3A%20calc%28100%20%2D%2060px%29%3B%0A%7D%0A%2ENavigationArea%20%7B%0Awidth%3A%20200px%3B%0Aheight%3A%20calc%28100%25%20%2D%2060px%29%3B%0Aoverflow%2Dy%3A%20auto%3B%0Abackground%3A%20%23f2f2f2%3B%0Apadding%3A%2030px%3B%0Aposition%3A%20fixed%3B%0Aheight%3A%20100vh%3B%0A%7D%0A%2ENavigationArea%2Dicon%20%7B%0Aheight%3A%2020px%3B%0Awidth%3A%2020px%3B%0Amargin%2Dbottom%3A%2035px%3B%0Amargin%2Dtop%3A%2010px%3B%0Acursor%3A%20pointer%3B%0Astroke%3A%20%23505050%3B%0A%7D%0A%2ENavigationArea%2Dicon%3Ahover%20%7B%0Astroke%3A%20%23409BDF%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%7B%0Awidth%3A%2030px%3B%0Abackground%3A%20white%3B%0Apadding%2Dright%3A%200%3B%0A%7D%0A%2ENavigationArea%20%2ENavigationArea%2Dicon%2D%2Dclose%20%7B%0Adisplay%3A%20block%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%2ENavigationArea%2DlinkContainer%2C%0A%2ENavigationArea%2D%2Dclosed%20%2ENavigationArea%2Dicon%2D%2Dclose%2C%0A%2ENavigationArea%20%2ENavigationArea%2Dicon%2D%2Dopen%20%7B%0Adisplay%3A%20none%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%2ENavigationArea%2Dicon%2D%2Dopen%20%7B%0Adisplay%3A%20block%3B%0A%7D%0A%2ENavigationArea%2DlinkContainer%20%7B%0Amargin%2Dbottom%3A%2030px%3B%0A%7D%0A%2ENavigationArea%2Dspacer%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23ccc%3B%0Amargin%3A%2020px%200%3B%0A%7D%0A%2ENavigationArea%2DnavLi%20%7B%0Afont%2Dsize%3A%2016px%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dprimary%20%7B%0Afont%2Dweight%3A%20700%3B%0A%7D%0A%2ENavigationArea%2DnavLi%20a%20%7B%0Acolor%3A%20%23443e3c%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dsecondary%20%7B%0Apadding%2Dleft%3A%2025px%3B%0Afont%2Dweight%3A%20normal%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2DalwaysHidden%20%7B%0Adisplay%3A%20none%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dsmaller%20%7B%0Afont%2Dsize%3A%2013px%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dclosed%20%7B%0Adisplay%3A%20none%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dselected%20%3E%20a%20%7B%0Acolor%3A%20%23409BDF%3B%0A%7D%0A%2EContent%20%7B%0Apadding%3A%200%2020px%3B%0Aheight%3A%20calc%28100%25%20%2D%2062px%29%3B%0Aoverflow%2Dy%3A%20scroll%3B%0A%2Dwebkit%2Doverflow%2Dscrolling%3A%20touch%3B%0Amax%2Dwidth%3A%20100%25%3B%0Aoverflow%2Dx%3A%20hidden%3B%0Aflex%3A%201%3B%0Amargin%2Dtop%3A%2040px%3B%0Amargin%2Dleft%3A%20220px%3B%0A%7D%0A%2EContent%2Dinner%20%7B%0Awidth%3A%20100%25%3B%0Amax%2Dwidth%3A%20800px%3B%0Amargin%2Dleft%3A%2060px%3B%0Amargin%2Dtop%3A%2034px%3B%0Apadding%2Dtop%3A%201px%3B%0A%7D%0A%2EContent%2Dinner%2D%2Dhidden%20%7B%0Adisplay%3A%20none%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%7E%20%2EContent%20%7B%0Amargin%2Dleft%3A%2020px%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%7E%20%2EContent%20%2EContent%2Dinner%20%7B%0Amargin%2Dleft%3A%2040px%3B%0A%7D%0A%40media%20only%20screen%20and%20%28max%2Dwidth%3A%201220px%29%20%7B%0A%2EContent%2Dinner%20%7B%0Awidth%3A%20calc%28100%25%20%2D%20120px%29%3B%0Amax%2Dwidth%3A%20calc%28100%25%20%2D%20120px%29%3B%0A%7D%0A%7D%0A%40media%20only%20screen%20and%20%28max%2Dwidth%3A%20800px%29%20%7B%0A%2ENavigationArea%20%7B%0Aposition%3A%20block%3B%0Az%2Dindex%3A%201%3B%0Awidth%3A%20calc%28100%25%20%2D%2040px%29%3B%0Aheight%3A%20100%25%3B%0Apadding%3A%2020px%3B%0Apadding%2Dbottom%3A%200px%3B%0Aoverflow%2Dy%3A%20scroll%3B%0A%2Dwebkit%2Doverflow%2Dscrolling%3A%20touch%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%7B%0Aposition%3A%20fixed%3B%0Aheight%3A%2050px%3B%0A%7D%0A%2ENavigationArea%2DlinkContainer%20%7B%0Apadding%2Dbottom%3A%2050px%3B%0A%7D%0A%2ENavigationArea%2DnavLi%2D%2Dclosed%20%7B%0Adisplay%3A%20block%3B%0A%7D%0A%2ENavigationArea%20%2B%20%2EContent%20%7B%0Adisplay%3A%20none%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%2B%20%2EContent%20%7B%0Adisplay%3A%20block%3B%0A%7D%0A%2ENavigationArea%2Dicon%20%7B%0Amargin%3A%200%3B%0A%7D%0A%2EContent%20%7B%0Amargin%2Dtop%3A%2040px%3B%0Amargin%2Dleft%3A%2020px%3B%0A%7D%0A%2EContent%2Dinner%20%7B%0Awidth%3A%20calc%28100%25%20%2D%2020px%29%3B%0Amax%2Dwidth%3A%20calc%28100%25%20%2D%2020px%29%3B%0Amargin%2Dleft%3A%200%3B%0A%7D%0A%2ENavigationArea%2D%2Dclosed%20%7E%20%2EContent%20%2EContent%2Dinner%20%7B%0Amargin%2Dleft%3A%200%3B%0A%7D%0A%7D%0A" rel="stylesheet">
-        
-        
+
+
         <!--[if lt IE 9]>
             <script
                 src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js">
@@ -23,8 +23,8 @@
 
             </head>
     <body>
-        
-        
+
+
         <svg style="display: none;">
             <symbol id="custom-hamburger-icon" viewBox="0 0 22 17" xmlns="http://www.w3.org/2000/svg">
                     <g id="Page-1" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
@@ -62,9 +62,10 @@
                 </div>
                 <nav class="NavigationArea-linkContainer" id="TOC">
                     <ul>
-                    <li><a href="#teletype-v3.1.0">Teletype v3.1.0</a></li>
+                    <li><a href="#teletype-v3.2.0-documentation">Teletype v3.2.0 Documentation</a></li>
                     <li><a href="#introduction">Introduction</a></li>
                     <li><a href="#updates">Updates</a><ul>
+                    <li><a href="#version-3.2">Version 3.2</a></li>
                     <li><a href="#version-3.1">Version 3.1</a></li>
                     <li><a href="#version-3.0">Version 3.0</a></li>
                     <li><a href="#version-2.2">Version 2.2</a></li>
@@ -117,6 +118,7 @@
                     <li><a href="#alphabetical-list-of-ops-and-mods">Alphabetical list of OPs and MODs</a></li>
                     <li><a href="#missing-documentation">Missing documentation</a></li>
                     <li><a href="#changelog">Changelog</a><ul>
+                    <li><a href="#v3.1.x">v3.1.x</a></li>
                     <li><a href="#v3.1.0">v3.1.0</a></li>
                     <li><a href="#v3.0.0">v3.0.0</a></li>
                     <li><a href="#v2.2">v2.2</a></li>
@@ -134,18 +136,33 @@
             </div>
                 <div class="Content">
             <div class="Content-inner Content-inner--hidden">
-                <h1 id="teletype-v3.1.0">Teletype v3.1.0</h1>
-                <p>Documentation</p>
+                <h1 id="teletype-v3.2.0-documentation">Teletype v3.2.0 Documentation</h1>
                 <h1 id="introduction">Introduction</h1>
                 <p>Teletype is a dynamic, musical event triggering platform.</p>
                 <ul>
                 <li><a href="https://monome.org/docs/modular/teletype/studies-1">Teletype Studies</a> - guided series of tutorials</li>
                 <li><p><a href="https://monome.org/docs/modular/teletype/TT_commands_3.0.pdf">PDF command reference chart</a> — <a href="https://monome.org/docs/modular/teletype/TT_scene_RECALL_sheet.pdf">PDF scene recall sheet</a> — <a href="http://monome.org/docs/modular/teletype/scenes-1.0/">Default scenes</a></p></li>
-                <li><p>Current version: <em>3.1.0 </em> — <a href="https://monome.org/docs/modular/update/">Firmware update procedure</a></p></li>
+                <li><p>Current version: <em>3.2.0</em> — <a href="https://monome.org/docs/modular/update/">Firmware update procedure</a></p></li>
                 </ul>
                 <h1 id="updates">Updates</h1>
-                <h2 id="version-3.1">Version 3.1</h2>
+                <h2 id="version-3.2">Version 3.2</h2>
                 <h3 id="new-operators">New operators</h3>
+                <p><code>LROT</code> (alias <code>&lt;&lt;&lt;</code>) / <code>RROT</code> (alias <code>&gt;&gt;&gt;</code>) - rotate bits in a number left or right. These ops as well as <code>LSH</code> and <code>RSH</code> ops will now accept negative numbers, shifting the opposite direction.</p>
+                <p><code>SGN</code> - signum / sign of argument function: <code>SGN 0</code> = <code>0</code>, <code>SGN</code> of positive = 1, <code>SGN</code> of negative = -1.</p>
+                <p><code>NR</code> - generate patterns or rhythms with bitwise arithmetic.</p>
+                <p><code>N.S</code>, <code>N.C</code>, <code>N.S</code> - look up values from the <code>N</code> table using Western scales and chords.</p>
+                <p><code>FADER.SCALE</code>, <code>FADER.CAL.MIN</code>, <code>FADER.CAL.MAX</code>, <code>FADER.CAL.RESET</code> - scale and calibrate 16n faderbank values</p>
+                <p><code>P.SHUF</code>, <code>P.REV</code>, <code>P.ROT</code> (and <code>PN</code> versions) - shuffle, reverse, or rotate an entire pattern (between its <code>START</code> and <code>END</code>)</p>
+                <p>The <code>SCRIPT</code> or <code>$</code> op can now call the metro script (<code>SCRIPT 9</code>) or init script (<code>SCRIPT 10</code>).</p>
+                <h3 id="new-kria-op">New Kria op</h3>
+                <p><code>KR.DUR</code> - read the current duration value</p>
+                <h3 id="new-mods">New mods</h3>
+                <p><code>P.MAP:</code>, <code>PN.MAP x:</code> - transform a pattern by evaluating the following command, placing the pattern value in <code>I</code></p>
+                <h3 id="new-keybindings">New keybindings</h3>
+                <p>In help mode, use <code>C-s</code> or <code>C-f</code> to search forward and <code>C-r</code> to search backward. <code>ENTER</code> to go to the next search hit in either direction.</p>
+                <p>In pattern mode, several new keybindings have been introduced by nudging pattern cells by semitones, fifths, or octaves. See &quot;Tracker mode&quot; for all keybindings.</p>
+                <h2 id="version-3.1">Version 3.1</h2>
+                <h3 id="new-operators-1">New operators</h3>
                 <p><code>DEVICE.FLIP</code> - change how screen is displayed and how I/O are numbered to let you mount the module upside down</p>
                 <p><code>DEL.X</code>, <code>DEL.R</code> - repeat an action multiple times, separated by a delay</p>
                 <p><code>J</code> &amp; <code>K</code> local script variables</p>
@@ -179,7 +196,7 @@
                 <p>The SSSR Labs SM010 Matrixarchate is a 16x8 IO Sequenceable Matrix Signal Router. Teletype integration allows you to switch programs and control connections. For a complete list of available ops refer to the manual. Information on how to connect the module can be found <a href="https://www.sssrlabs.com/store/sm010/">in the SM010 manual</a>.</p>
                 <h4 id="support-for-w-via-i2c">Support for W/ via i2c</h4>
                 <p>Support for controlling Whimsical Raps W/ module via i2c. See the respective section for a complete list of available ops and refer to https://www.whimsicalraps.com/pages/w-type for more details.</p>
-                <h3 id="new-operators-1">New operators</h3>
+                <h3 id="new-operators-2">New operators</h3>
                 <p><code>? x y z</code> is a ternary &quot;if&quot; operator, it will select between <code>y</code> and <code>z</code> based on the condition <code>x</code>.</p>
                 <h4 id="new-pattern-ops">New pattern ops</h4>
                 <p><code>P.MIN</code> <code>PN.MIN</code> <code>P.MAX</code> <code>PN.MAX</code> return the position for the first smallest/largest value in a pattern between the <code>START</code> and <code>END</code> points.</p>
@@ -201,7 +218,7 @@
                 <p><code>RND</code> / <code>RRND</code> <code>RAND</code> / <code>RRAND</code></p>
                 <p><code>WRP</code> for <code>WRAP</code></p>
                 <p><code>SCL</code> for <code>SCALE</code></p>
-                <h3 id="new-keybindings">New keybindings</h3>
+                <h3 id="new-keybindings-1">New keybindings</h3>
                 <p>Hold <code>shift</code> while making line selection in script editing to select multiple lines. Use <code>alt-&lt;up&gt;</code> and <code>alt-&lt;down&gt;</code> to move selected lines up and down. Copy/cut/paste shortcuts work with multiline selection as well. To delete selected lines without copying into the clipboard use <code>alt-&lt;delete&gt;</code>.</p>
                 <p>While editing a line you can now use <code>ctrl-&lt;left&gt;</code> / <code>ctrl-&lt;right&gt;</code> to move by words.</p>
                 <p><code>ctrl-z</code> provides three level undo in script editing.</p>
@@ -240,7 +257,7 @@
                 <p>This helps the user to quickly check and monitor variables across the Teletype. Instead of single command line parameter checks the user is now able to simply press the <code>~ key</code> (Tilde) and have a persistent display of eight system variables.</p>
                 <h4 id="screensaver">Screensaver</h4>
                 <p>Screen saver engages after 90 minutes of inactivity</p>
-                <h4 id="new-operators-2">New Operators</h4>
+                <h4 id="new-operators-3">New Operators</h4>
                 <ul>
                 <li><code>IN.SCALE min max</code> sets the min/max values of the CV Input jack</li>
                 <li><code>PARAM.SCALE min max</code> set the min/max scale of the Parameter Knob</li>
@@ -282,11 +299,11 @@
                 <p>Finally, SYNC X will set each EVERY and SKIP counter to X without modifying its divisor value. Using a negative number will set it to that number of steps before the step. Using SYNC -1 will cause each EVERY to execute on its next call, and each SKIP will not execute.</p>
                 <h4 id="script-line-commenting">Script Line &quot;Commenting&quot;</h4>
                 <p>Individual lines in scripts can now be disabled from execution by highlighting the line and pressing <code>ALT-/</code>. Disabled lines will appear dim. This status will persist through save/load from flash, but will not carry over to scenes saved to USB drive.</p>
-                <h3 id="new-operators-3">New Operators</h3>
+                <h3 id="new-operators-4">New Operators</h3>
                 <p><code>W [condition]:</code> is a new mod that operates as a while loop. The <code>BREAK</code> operator stops executing the current script <code>BPM [bpm]</code> returns the number of milliseconds per beat in a given BPM, great for setting <code>M</code>. <code>LAST [script]</code> returns the number of milliseconds since <code>script</code> was last called.</p>
                 <h3 id="new-operator-behaviour">New Operator Behaviour</h3>
                 <p><code>SCRIPT</code> with no argument now returns the current script number. <code>I</code> is now local to its corresponding <code>L</code> statement. <code>IF/ELSE</code> is now local to its script.</p>
-                <h3 id="new-keybindings-1">New keybindings</h3>
+                <h3 id="new-keybindings-2">New keybindings</h3>
                 <p><code>CTRL-1</code> through <code>CTRL-8</code> toggle the mute status for scripts 1 to 8 respectively. <code>CTRL-9</code> toggles the METRO script. <code>SHIFT-ENTER</code> now inserts a line in Scene Write mode.</p>
                 <h3 id="bug-fixes-2">Bug fixes</h3>
                 <p>Temporal recursion now possible by fixing delay allocation issue, e.g.: DEL 250: SCRIPT SCRIPT <code>KILL</code> now clears <code>TR</code> outputs and stops METRO. <code>SCENE</code> will no longer execute from the INIT script on initial scene load. <code>AVG</code> and <code>Q.AVG</code> now round up from offsets of 0.5 and greater.</p>
@@ -313,7 +330,7 @@
                 PN.START 1 10</code></pre>
                 <h4 id="telexi-and-telexo-ops">TELEXi and TELEXo <code>OP</code>s</h4>
                 <p>Lots of <code>OP</code>s have been added for interacting with the wonderful TELEXi input expander and TELEXo output expander. See their respective sections in the documentation for more information.</p>
-                <h4 id="new-keybindings-2">New keybindings</h4>
+                <h4 id="new-keybindings-3">New keybindings</h4>
                 <p>The function keys can now directly trigger a script.</p>
                 <p>The <code>&lt;tab&gt;</code> key is now used to cycle between live, edit and pattern modes, and there are now easy access keys to directly jump to a mode.</p>
                 <p>Many new text editing keyboard shortcuts have been added.</p>
@@ -824,6 +841,38 @@
                 <td>increment by 1</td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>alt-[</code></strong></td>
+                <td>decrement by 1 semitone</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>alt-]</code></strong></td>
+                <td>increment by 1 semitone</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>ctrl-[</code></strong></td>
+                <td>decrement by 7 semitones</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>ctrl-]</code></strong></td>
+                <td>increment by 7 semitones</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>shift-[</code></strong></td>
+                <td>decrement by 12 semitones</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>shift-]</code></strong></td>
+                <td>increment by 12 semitones</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>alt-&lt;0-9&gt;</code></strong></td>
+                <td>increment by <code>&lt;0-9&gt;</code> semitones (0=10, 1=11)</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>shift-alt-&lt;0-9&gt;</code></strong></td>
+                <td>decrement by <code>&lt;0-9&gt;</code> semitones (0=10, 1=11)</td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>&lt;backspace&gt;</code></strong></td>
                 <td>delete a digit</td>
                 </tr>
@@ -1000,11 +1049,19 @@
                 <td><strong><code>&lt;right&gt;</code></strong> / <strong><code>]</code></strong></td>
                 <td>next page</td>
                 </tr>
+                <tr class="odd">
+                <td><strong><code>C-f</code></strong> / <strong><code>C-s</code></strong></td>
+                <td>search forward</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>C-r</code></strong></td>
+                <td>search backward</td>
+                </tr>
                 </tbody>
                 </table>
                 </div>
                 <h1 id="ops-and-mods">OPs and MODs</h1>
-                
+
                 <h2 id="variables">Variables</h2>
                 <p>General purpose temp vars: <code>X</code>, <code>Y</code>, <code>Z</code>, and <code>T</code>.</p>
                 <p><code>T</code> typically used for time values, but can be used freely.</p>
@@ -1178,7 +1235,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="hardware">Hardware</h2>
                 <p>The Teletype trigger inputs are numbered 1-8, the CV and trigger outputs 1-4. See the Ansible documentation for details of the Ansible output numbering when in Teletype mode.</p>
                 <!--
@@ -1338,7 +1395,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="patterns-1">Patterns</h2>
                 <p>Patterns facilitate musical data manipulation– lists of numbers that can be used as sequences, chord sets, rhythms, or whatever you choose. Pattern memory consists four banks of 64 steps. Functions are provided for a variety of pattern creation, transformation, and playback.</p>
                 <p>New in teletype 2.0, a second version of all Pattern ops have been added. The original <code>P</code> ops (<code>P</code>, <code>P.L</code>, <code>P.NEXT</code>, etc.) act upon the ‘working pattern’ as defined by <code>P.N</code>. By default the working pattern is assigned to pattern 0 (<code>P.N 0</code>), in order to execute a command on pattern 1 using <code>P</code> ops you would need to first reassign the working pattern to pattern 1 (<code>P.N 1</code>).</p>
@@ -1557,6 +1614,42 @@
                 <td>find the first maximum value in the pattern between the START and END for pattern <code>x</code> and return its index</td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>P.SHUF</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>shuffle the values in active pattern (between its START and END)</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>PN.SHUF x</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>shuffle the values in pattern <code>x</code> (between its START and END)</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>P.ROT n</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>rotate the values in the active pattern <code>n</code> steps (between its START and END, negative rotates backward)</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>PN.ROT x n</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>rotate the values in pattern <code>x</code> (between its START and END, negative rotates backward)</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>P.REV</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>reverse the values in the active pattern (between its START and END)</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>PN.REV x</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>reverse the values in pattern <code>x</code></td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>P.RND</code></strong></td>
                 <td>-</td>
                 <td>-</td>
@@ -1616,10 +1709,22 @@
                 <td>-</td>
                 <td>decrease the value of pattern <code>x</code> at index <code>y</code> by <code>z</code> and wrap it to <code>a</code>..<code>b</code> range</td>
                 </tr>
+                <tr class="even">
+                <td><strong><code>P.MAP: ...</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>Replace each cell in the active pattern (between the START and END of the pattern) by assigning<br />the variable I to the current value of the cell, evaluating the command after the mod, and<br />assigning that pattern cell with the result. The 'map' higher-order function from functional<br />programming, with the command giving the function of <code>I</code> to map over the pattern.<br /><br />For example:<br /><br /><code>&lt;br/&gt;P.MAP: * 2 I  =&gt; double each cell in the active pattern&lt;br/&gt;</code><br /></td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>PN.MAP x: ...</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>apply the 'function' to each value in pattern <code>x</code>, <code>I</code> takes each pattern value</td>
+                </tr>
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="control-flow">Control flow</h2>
                 <!--
                 make sure that the description column is long!
@@ -1707,7 +1812,7 @@
                 <td><strong><code>SCRIPT</code></strong></td>
                 <td><strong><code>SCRIPT x</code></strong></td>
                 <td><strong><code>$</code></strong></td>
-                <td>Execute script <code>x</code> (1-8), recursion allowed.<br /><br />There is a limit of 8 for the maximum number of nested calls to <code>SCRIPT</code> to stop infinite loops from locking up the Teletype.<br /></td>
+                <td>Execute script <code>x</code> (1-10, 9 = metro, 10 = init), recursion allowed.<br /><br />There is a limit of 8 for the maximum number of nested calls to <code>SCRIPT</code> to stop infinite loops from locking up the Teletype.<br /></td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>SCRIPT.POL x</code></strong></td>
@@ -1814,7 +1919,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="maths">Maths</h2>
                 <p>Logical operators such as <code>EQ</code>, <code>OR</code> and <code>LT</code> return <code>1</code> for true, and <code>0</code> for false.</p>
                 <!--
@@ -1990,6 +2095,18 @@
                 <td>right shift <code>x</code> by <code>y</code> bits, in effect divide <code>x</code> by <code>2</code> to the power of <code>y</code></td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>LROT x y</code></strong></td>
+                <td>-</td>
+                <td><strong><code>&lt;&lt;&lt;</code></strong></td>
+                <td>circular left shift <code>x</code> by <code>y</code> bits, wrapping around when bits fall off the end</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>RROT x y</code></strong></td>
+                <td>-</td>
+                <td><strong><code>&gt;&gt;&gt;</code></strong></td>
+                <td>circular right shift <code>x</code> by <code>y</code> bits, wrapping around when bits fall off the end</td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>| x y</code></strong></td>
                 <td>-</td>
                 <td>-</td>
@@ -2068,16 +2185,40 @@
                 <td>Euclidean rhythm helper, as described by Godfried Toussaint in his 2005 paper [&quot;The Euclidean Algorithm Generates Traditional Musical Rhythms&quot;][euclidean_rhythm_paper][^euclidean_rhythm_citation]. From the abstract:<br /><br /> - <code>f</code> is fill (<code>1-32</code>) and should be less then or equal to length<br /> - <code>l</code> is length (<code>1-32</code>)<br /> - <code>i</code> is the step index, and will work with negative as well as positive numbers<br /><br />If you wish to add rotation as well, use the following form:<br /><br /><code>&lt;br/&gt;ER f l SUB i r&lt;br/&gt;</code><br /><br />where <code>r</code> is the number of step of <em>forward</em> rotation you want.<br /><br />For more info, see the post on [samdoshi.com][samdoshi_com_euclidean]<br /><br />[samdoshi_com_euclidean]: http://samdoshi.com/post/2016/03/teletype-euclidean/<br />[euclidean_rhythm_paper]: http://cgm.cs.mcgill.ca/~godfried/publications/banff.pdf<br />[^euclidean_rhythm_citation]: Toussaint, G. T. (2005, July). The Euclidean algorithm generates traditional musical rhythms. <em>In Proceedings of BRIDGES: Mathematical Connections in Art, Music and Science</em> (pp. 47-56).<br /></td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>NR p m f s</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>Numeric Repeater is similar to ER, except it generates patterns using the binary arithmetic process found in [&quot;Noise Engineering's Numeric Repetitor&quot;][numeric_repetitor]. From the description:<br /><br />Numeric Repetitor is a rhythmic gate generator based on binary arithmetic. A core pattern forms the basis and variation is achieved by treating this pattern as a binary number and multiplying it by another. NR contains 32 prime rhythms derived by examining all possible rhythms and weeding out bad ones via heuristic.<br /><br />All parameters wrap around their specified ranges automatically and support negative indexing.<br /><br />Masks<br /> - <code>0</code> is no mask<br /> - <code>1</code> is <code>0x0F0F</code><br /> - <code>2</code> is <code>0xF003</code><br /> - <code>3</code> is <code>0x1F0</code><br /><br />For further detail [&quot;see the manual&quot;][nr_manual].<br /><br />[numeric_repetitor]: https://www.noiseengineering.us/shop/numeric-repetitor<br />[nr_manual]: https://static1.squarespace.com/static/58c709192e69cf2422026fa6/t/5e6041ad4cbc0979d6d793f2/1583366574430/NR_manual.pdf<br /></td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>BPM x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>milliseconds per beat in BPM <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>N x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>The <code>N</code> OP converts an equal temperament note number to a value usable by the CV outputs.<br /><br />Examples:<br /><br /><code>&lt;br/&gt;CV 1 N 60        =&gt; set CV 1 to middle C, i.e. 5V&lt;br/&gt;CV 1 N RAND 24   =&gt; set CV 1 to a random note from the lowest 2 octaves&lt;br/&gt;</code><br /></td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>N.S r s d</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>The <code>N.S</code> OP lets you retrieve <code>N</code> table values according to traditional western scales. <code>s</code> and <code>d</code> wrap to their ranges automatically and support negative indexing.<br /><br />Scales<br /> - <code>0</code> = Major<br /> - <code>1</code> = Natural Minor<br /> - <code>2</code> = Harmonic Minor<br /> - <code>3</code> = Melodic Minor<br /> - <code>4</code> = Dorian<br /> - <code>5</code> = Phrygian<br /> - <code>6</code> = Lydian<br /> - <code>7</code> = Myxolidian<br /> - <code>8</code> = Locrian<br /></td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>N.C r c d</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>The <code>N.C</code> OP lets you retrieve <code>N</code> table values according to traditional western chords. <code>c</code> and <code>d</code> wrap to their ranges automatically and support negative indexing.<br /><br />Chords<br /> - <code>0</code> = Major 7th <code>{0, 4, 7, 11}</code><br /> - <code>1</code> = Minor 7th <code>{0, 3, 7, 10}</code><br /> - <code>2</code> = Dominant 7th <code>{0, 4, 7, 10}</code><br /> - <code>3</code> = Diminished 7th <code>{0, 3, 6, 9}</code><br /> - <code>4</code> = Augmented 7th <code>{0, 4, 8, 10}</code><br /> - <code>5</code> = Dominant 7b5 <code>{0, 4, 6, 10}</code><br /> - <code>6</code> = Minor 7b5 <code>{0, 3, 6, 10}</code><br /> - <code>7</code> = Major 7#5 <code>{0, 4, 8, 11}</code><br /> - <code>8</code> = Minor Major 7th <code>{0, 3, 7, 11}</code><br /> - <code>9</code> = Diminished Major 7th <code>{0, 3, 6, 11}</code><br /> - <code>10</code> = Major 6th <code>{0, 4, 7, 9}</code><br /> - <code>11</code> = Minor 6th <code>{0, 3, 7, 9}</code><br /> - <code>12</code> = 7sus4 <code>{0, 5, 7, 10}</code><br /></td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>N.CS r s d c</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>The <code>N.CS</code> OP lets you retrieve <code>N</code> table values according to traditional western scales and chords. <code>s</code>, <code>c</code> and <code>d</code> wrap to their ranges automatically and support negative indexing.<br /><br />Chord Scales - Refer to chord indices in <code>N.C</code> OP<br /> - <code>0</code> = Major <code>{0, 1, 1, 0, 2, 1, 6}</code><br /> - <code>1</code> = Natural Minor <code>{1, 6, 0, 1, 1, 0, 2}</code><br /> - <code>2</code> = Harmonic Minor <code>{8, 6, 7, 1, 2, 0, 3}</code><br /> - <code>3</code> = Melodic Minor <code>{8, 1, 7, 2, 2, 6, 6}</code><br /> - <code>4</code> = Dorian <code>{1, 1, 0, 2, 1, 6, 0}</code><br /> - <code>5</code> = Phrygian <code>{1, 0, 2, 1, 6, 0, 1}</code><br /> - <code>6</code> = Lydian <code>{0, 2, 1, 6, 0, 1, 1}</code><br /> - <code>7</code> = Myxolidian <code>{6, 0, 1, 1, 0, 2, 1}</code><br /> - <code>8</code> = Locrian <code>{6, 0, 1, 1, 0, 2, 1}</code><br /></td>
                 </tr>
                 <tr class="odd">
                 <td><strong><code>V x</code></strong></td>
@@ -2098,36 +2239,42 @@
                 <td>exponentiation table lookup. <code>0-16383</code> range (V <code>0-10</code>)</td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>SGN x</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>sign function: 1 for positive, -1 for negative, 0 for 0</td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>CHAOS x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get next value from chaos generator, or set the current value</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>CHAOS.R x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get or set the <code>R</code> parameter for the <code>CHAOS</code> generator</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>CHAOS.ALG x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get or set the algorithm for the <code>CHAOS</code> generator. 0 = LOGISTIC, 1 = CUBIC, 2 = HENON, 3 = CELLULAR</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>R</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>generate a random number</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>R.MIN x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set the lower end of the range from 0 – 32767</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>R.MAX x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
@@ -2136,7 +2283,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="metronome-1">Metronome</h2>
                 <p>An internal metronome executes the M script at a specified rate (in ms). By default the metronome is enabled (<code>M.ACT 1</code>) and set to 1000ms (<code>M 1000</code>). The metro can be set as fast as 25ms (<code>M 25</code>). An additional <code>M!</code> op allows for setting the metronome to experimental rates as high as 2ms (<code>M! 2</code>). <strong>WARNING</strong>: when using a large number of i2c commands in the M script at metro speeds beyond the 25ms teletype stability issues can occur.</p>
                 <p>Access the M script directly with <code>alt-&lt;F10&gt;</code> or run the script once using <code>&lt;F10&gt;</code>.</p>
@@ -2189,7 +2336,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="delay">Delay</h2>
                 <p>The <code>DEL</code> delay op allow commands to be sheduled for execution after a defined interval by placing them into a buffer which can hold up to 16 commands. Commands can be delayed by up to 16 seconds</p>
                 <p>In LIVE mode, the second icon (an upside-down U) will be lit up when there is a command in the <code>DEL</code> buffer.</p>
@@ -2242,7 +2389,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="stack">Stack</h2>
                 <p>These operators manage a last in, first out, stack of commands, allowing them to be memorised for later execution at an unspecified time. The stack can hold up to 8 commands. Commands added to a full stack will be discarded.</p>
                 <!--
@@ -2300,7 +2447,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="queue">Queue</h2>
                 <p>These operators manage a first in, first out, queue of values. The queue can hold up to 16 values. The length of the queue can be dynamically changed and the contents will be preserved. There is also an averaging operator which is useful for smoothing input values.</p>
                 <!--
@@ -2346,7 +2493,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="seed">Seed</h2>
                 <!--
                 make sure that the description column is long!
@@ -2409,7 +2556,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="turtle">Turtle</h2>
                 <p>A 2-dimensional, movable index into the pattern values as displayed on the TRACKER screen.</p>
                 <!--
@@ -2539,7 +2686,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="grid">Grid</h2>
                 <p>Grid operators allow creating scenes that can interact with grid connected to teletype (important: grid must be powered externally, do not connect it directly to teletype!). You can light up individual LEDs, draw shapes and create controls (such as buttons and faders) that can be used to trigger and control scripts. You can take advantage of grid operators even without an actual grid by using the built in Grid Visualizer.</p>
                 <p>For more information on grid integration see Advanced section and <a href="https://github.com/scanner-darkly/teletype/wiki/GRID-INTEGRATION">Grid Studies</a>.</p>
@@ -2951,7 +3098,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="ansible">Ansible</h2>
                 <!--
                 make sure that the description column is long!
@@ -3102,186 +3249,192 @@
                 <td>Get or change the step direction. Numbered from 0.<br /></td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>KR.DUR x</code></strong></td>
+                <td>-</td>
+                <td>-</td>
+                <td>get the current duration value for channel <code>x</code></td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>ME.PRE</code></strong></td>
                 <td><strong><code>ME.PRE x</code></strong></td>
                 <td>-</td>
                 <td>return current preset / load preset <code>x</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ME.SCALE</code></strong></td>
                 <td><strong><code>ME.SCALE x</code></strong></td>
                 <td>-</td>
                 <td>get/set current scale</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ME.PERIOD</code></strong></td>
                 <td><strong><code>ME.PERIOD x</code></strong></td>
                 <td>-</td>
                 <td>get/set internal clock period</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ME.STOP x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>stop channel <code>x</code> (<code>0</code> = all)</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ME.RES x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>reset channel <code>x</code> (<code>0</code> = all), also used as &quot;start&quot;</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ME.CV x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get the current CV value for channel <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>LV.PRE</code></strong></td>
                 <td><strong><code>LV.PRE x</code></strong></td>
                 <td>-</td>
                 <td>return current preset / load preset <code>x</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>LV.RES x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>reset, <code>0</code> for soft reset (on next ext. clock), <code>1</code> for hard reset</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>LV.POS</code></strong></td>
                 <td><strong><code>LV.POS x</code></strong></td>
                 <td>-</td>
                 <td>get/set current position</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>LV.L.ST</code></strong></td>
                 <td><strong><code>LV.L.ST x</code></strong></td>
                 <td>-</td>
                 <td>get/set loop start</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>LV.L.LEN</code></strong></td>
                 <td><strong><code>LV.L.LEN x</code></strong></td>
                 <td>-</td>
                 <td>get/set loop length</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>LV.L.DIR</code></strong></td>
                 <td><strong><code>LV.L.DIR x</code></strong></td>
                 <td>-</td>
                 <td>get/set loop direction</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>LV.CV x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get the current CV value for channel <code>x</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>CY.PRE</code></strong></td>
                 <td><strong><code>CY.PRE x</code></strong></td>
                 <td>-</td>
                 <td>return current preset / load preset <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>CY.RES x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>reset channel <code>x</code> (<code>0</code> = all)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>CY.POS x</code></strong></td>
                 <td><strong><code>CY.POS x y</code></strong></td>
                 <td>-</td>
                 <td>get / set position of channel <code>x</code> (<code>x = 0</code> to set all), position between <code>0-255</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>CY.REV x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>reverse channel <code>x</code> (<code>0</code> = all)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>CY.CV x</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>get the current CV value for channel <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>MID.SLEW t</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set pitch slew time in ms (applies to all allocation styles except FIXED)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>MID.SHIFT o</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>shift pitch CV by standard Teletype pitch value (e.g. <code>N 6</code>, <code>V -1</code>, etc)</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.HLD h</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td><code>0</code> disables key hold mode, other values enable</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ARP.STY y</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set base arp style [0-7]</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.GT v g</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice gate length [0-127], scaled/synced to course divisions of voice clock</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ARP.SLEW v t</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice slew time in ms</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.RPT v n s</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice pattern repeat, <code>n</code> times [0-8], shifted by <code>s</code> semitones [-24, 24]</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ARP.DIV v d</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice clock divisor (euclidean length), range [1-32]</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.FIL v f</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice euclidean fill, use 1 for straight clock division, range [1-32]</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ARP.ROT v r</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set voice euclidean rotation, range [-32, 32]</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.ER v f d r</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>set all euclidean rhythm</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>ARP.RES v</code></strong></td>
                 <td>-</td>
                 <td>-</td>
                 <td>reset voice clock/pattern on next base clock tick</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>ARP.SHIFT v o</code></strong></td>
                 <td>-</td>
                 <td>-</td>
@@ -3290,7 +3443,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="white-whale">White Whale</h2>
                 <!--
                 make sure that the description column is long!
@@ -3401,7 +3554,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="meadowphysics">Meadowphysics</h2>
                 <p>For use on the original Meadowphysics module with version 2 firmware. Reference the Ansible ops for using Meadowphysics on the Ansible module.</p>
                 <!--
@@ -3447,7 +3600,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="earthsea">Earthsea</h2>
                 <!--
                 make sure that the description column is long!
@@ -3528,7 +3681,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="orca">Orca</h2>
                 <p>Remote commands for Orca (alternative WW firmware). For detailed info and tips on usage please refer to the <a href="https://github.com/scanner-darkly/monome-mods/wiki/Orca---manual#teletype-integration">Orca manual</a>.</p>
                 <!--
@@ -3652,7 +3805,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="just-friends">Just Friends</h2>
                 <p>More extensively covered in the <a href="https://www.whimsicalraps.com/pages/just-type">Just Friends Documentation</a>.</p>
                 <!--
@@ -3752,7 +3905,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="telexi">TELEXi</h2>
                 <p>The TELEXi (or TXi) is an input expander that adds 4 IN jacks and 4 PARAM knobs to the Teletype. There are jumpers on the back so you can hook more than one TXi to your Teletype simultaneously.</p>
                 <p>Inputs added to the system by the TELEX modules are addressed sequentially: 1-4 are on your first module of any type, 5-8 are on the second, 9-12 on the third, and so on. A few of the commands reference the module by its unit number – but those are rare.</p>
@@ -3883,7 +4036,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="telexo">TELEXo</h2>
                 <p>The TELEXo (or TXo) is an output expander that adds an additional 4 Trigger and 4 CV jacks to the Teletype. There are jumpers on the back so you can hook more than one TXo to your Teletype simultaneously.</p>
                 <p>Outputs added to the system by the TELEX modules are addressed sequentially: 1-4 are on your first module of any type, 5-8 are on the second, 9-12 on the third, and so on. A few of the commands reference the module by its unit number – but those are rare.</p>
@@ -4399,7 +4552,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="er-301">ER-301</h2>
                 <p>The Orthogonal Devices ER-301 Sound Computer is a voltage-controllable canvas for digital signal processing algorithms available from Orthogonal Devices. It can communicate with the Teletype to send up to 100 triggers and 100 CV values per device. Up to three devices are software-selectable and correlate to outputs up to 300.</p>
                 <!--
@@ -4481,7 +4634,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="n">16n</h2>
                 <p>The 16n Faderbank is an open-source controller that can be polled by the Teletype to read the positions of its 16 sliders.</p>
                 <!--
@@ -4512,10 +4665,34 @@
                 <td><strong><code>FB</code></strong></td>
                 <td>reads the value of the <code>FADER</code> slider <code>x</code>; default return range is from 0 to 16383</td>
                 </tr>
+                <tr class="even">
+                <td><strong><code>FADER.SCALE x y z</code></strong></td>
+                <td>-</td>
+                <td><strong><code>FB.S</code></strong></td>
+                <td>Set static scaling of the <code>FADER x</code> to between <code>min</code> and <code>max</code>.</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>FADER.CAL.MIN x</code></strong></td>
+                <td>-</td>
+                <td><strong><code>FB.C.MIN</code></strong></td>
+                <td>1. Slide FADER x all the way down to the bottom<br /> 2. Execute <code>FADER.CAL.MIN x</code> from the live terminal<br /> 3. Call <code>FADER x</code> and confirm the 0 result<br /></td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>FADER.CAL.MAX x</code></strong></td>
+                <td>-</td>
+                <td><strong><code>FB.C.MAX</code></strong></td>
+                <td>1. Slide FADER x all the way up to the top<br /> 2. Execute <code>FADER.CAL.MAX x</code> from the live terminal<br /> 3. Call <code>FADER x</code> and verify that the result is 16383<br /></td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>FADER.CAL.RESET x</code></strong></td>
+                <td>-</td>
+                <td><strong><code>FB.C.R</code></strong></td>
+                <td>Resets the calibration for FADER x</td>
+                </tr>
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="w">W/</h2>
                 <p>More extensively covered in the <a href="https://www.whimsicalraps.com/pages/w-type">W/ Documentation</a>.</p>
                 <!--
@@ -4567,7 +4744,7 @@
                 </tbody>
                 </table>
                 </div>
-                
+
                 <h2 id="matrixarchate">Matrixarchate</h2>
                 <p>The SSSR Labs SM010 Matrixarchate is a 16x8 IO Sequenceable Matrix Signal Router.</p>
                 <!--
@@ -4775,7 +4952,7 @@
                 <p>It can be very useful while developing a script as you don't have to switch between the grid and the keyboard as often. To turn it on navigate to Live screen and press <code>Alt-G</code> (press again to switch to Full View / turn it off). You can also emulate button presses, which means it can even be used as an alternative to grid if you don't have one, especially in full mode - try it with one of the many <a href="https://github.com/scanner-darkly/teletype/wiki/CODE-EXCHANGE">grid scenes</a> already developed. For more information on how to use it please refer to <a href="https://github.com/scanner-darkly/teletype/wiki/GRID-VISUALIZER">the Grid Visualizer documentation</a>.</p>
                 <p>Grid Control Mode is a built in grid interface that allows you to use grid to trigger and mute scripts, edit variables and tracker values, save and load scenes, and more. It's available in addition to whatever grid interface you develop - simply press the front panel button while the grid is attached. It can serve as a simple way to use grid to control any scene even without using grid ops, but it can also be very helpful when used together with a scripted grid interface. For more information and diagrams please refer to <a href="https://github.com/scanner-darkly/teletype/wiki/GRID-CONTROL-MODE">the Grid Control documentation</a>,</p>
                 <p>If you do want to try and build your own grid interfaces <a href="https://github.com/scanner-darkly/teletype/wiki/GRID-INTEGRATION">the Grid Studies</a> is the best place to start.</p>
-                
+
                 <h1 id="alphabetical-list-of-ops-and-mods">Alphabetical list of OPs and MODs</h1>
                 <!--
                 make sure that the description column is long!
@@ -5150,6 +5327,22 @@
                 <tr class="odd">
                 <td><strong><code>FADER x</code></strong> <br /> <strong><code>FB</code></strong></td>
                 <td>reads the value of the <code>FADER</code> slider <code>x</code>; default return range is from 0 to 16383</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>FADER.CAL.MAX x</code></strong> <br /> <strong><code>FB.C.MAX</code></strong></td>
+                <td>Reads <code>FADER x</code> maximum position and assigns the maximum point</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>FADER.CAL.MIN x</code></strong> <br /> <strong><code>FB.C.MIN</code></strong></td>
+                <td>Reads <code>FADER x</code> minimum position and assigns a zero value</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>FADER.CAL.RESET x</code></strong> <br /> <strong><code>FB.C.R</code></strong></td>
+                <td>Resets the calibration for FADER x</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>FADER.SCALE x y z</code></strong> <br /> <strong><code>FB.S</code></strong></td>
+                <td>Set static scaling of the <code>FADER x</code> to between <code>min</code> and <code>max</code>.</td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>FLIP</code></strong> <br /><strong><code>FLIP x</code></strong></td>
@@ -5568,60 +5761,68 @@
                 <td>get/set the step direction</td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>KR.DUR x</code></strong></td>
+                <td>get the current duration value for channel <code>x</code></td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>KR.L.LEN x y</code></strong> <br /><strong><code>KR.L.LEN x y z</code></strong></td>
                 <td>get length of track <code>x</code>, parameter <code>y</code> / set to <code>z</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>KR.L.ST x y</code></strong> <br /><strong><code>KR.L.ST x y z</code></strong></td>
                 <td>get loop start for track <code>x</code>, parameter <code>y</code> / set to <code>z</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>KR.MUTE x</code></strong> <br /><strong><code>KR.MUTE x y</code></strong></td>
                 <td>get/set mute state for channel <code>x</code> (<code>1</code> = muted, <code>0</code> = unmuted)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>KR.PAT</code></strong> <br /><strong><code>KR.PAT x</code></strong></td>
                 <td>get/set current pattern</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>KR.PERIOD</code></strong> <br /><strong><code>KR.PERIOD x</code></strong></td>
                 <td>get/set internal clock period</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>KR.PG</code></strong> <br /><strong><code>KR.PG x</code></strong></td>
                 <td>get/set the active page</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>KR.POS x y</code></strong> <br /><strong><code>KR.POS x y z</code></strong></td>
                 <td>get/set position <code>z</code> for track <code>z</code>, parameter <code>y</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>KR.PRE</code></strong> <br /><strong><code>KR.PRE x</code></strong></td>
                 <td>return current preset / load preset <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>KR.RES x y</code></strong></td>
                 <td>reset position to loop start for track <code>x</code>, parameter <code>y</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>KR.SCALE</code></strong> <br /><strong><code>KR.SCALE x</code></strong></td>
                 <td>get/set current scale</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>KR.TMUTE x</code></strong></td>
                 <td>toggle mute state for channel <code>x</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>L x y: ...</code></strong></td>
                 <td>run the command sequentially with <code>I</code> values from <code>x</code> to <code>y</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>LAST x</code></strong></td>
                 <td>get value in milliseconds since last script run time</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>LIM x y z</code></strong></td>
                 <td>limit the value <code>x</code> to the range <code>y</code> to <code>z</code> inclusive</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>LROT x y</code></strong> <br /> <strong><code>&lt;&lt;&lt;</code></strong></td>
+                <td>circular left shift <code>x</code> by <code>y</code> bits, wrapping around when bits fall off the end</td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>LSH x y</code></strong> <br /> <strong><code>&lt;&lt;</code></strong></td>
@@ -5812,8 +6013,24 @@
                 <td>converts an equal temperament note number to a value usable by the CV outputs (<code>x</code> in the range <code>-127</code> to <code>127</code>)</td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>N.C r c d</code></strong></td>
+                <td>Note Chord operator, <code>r</code> is the root note (<code>0-127</code>), <code>c</code> is the chord (<code>0-12</code>) and <code>d</code> is the degree (<code>0-3</code>), returns a value from the <code>N</code> table.</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>N.CS r s d c</code></strong></td>
+                <td>Note Chord Scale operator, <code>r</code> is the root note (<code>0-127</code>), <code>s</code> is the scale (<code>0-8</code>), <code>d</code> is the scale degree (<code>0-6</code>) and <code>c</code> is the chord degree (<code>0-3</code>), returns a value from the <code>N</code> table.</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>N.S r s d</code></strong></td>
+                <td>Note Scale operator, <code>r</code> is the root note (<code>0-127</code>), <code>s</code> is the scale (<code>0-8</code>) and <code>d</code> is the degree (<code>0-6</code>), returns a value from the <code>N</code> table.</td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>NE x y</code></strong> <br /> <strong><code>!=</code></strong> , <strong><code>XOR</code></strong></td>
                 <td><code>x</code> is not equal to <code>y</code></td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>NR p m f s</code></strong></td>
+                <td>Numeric Repeater, <code>p</code> is prime pattern (<code>0-31</code>), <code>m</code> is &amp; mask (<code>0-3</code>), <code>f</code> is variation factor (<code>0-16</code>) and <code>s</code> is step (<code>0-15</code>), returns <code>0</code> or <code>1</code></td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>NZ x</code></strong></td>
@@ -5952,32 +6169,40 @@
                 <td>get/set pattern length of the working pattern, non-destructive to data</td>
                 </tr>
                 <tr class="even">
+                <td><strong><code>P.MAP: ...</code></strong></td>
+                <td>apply the 'function' to each value in the active pattern, <code>I</code> takes each pattern value</td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>P.MAX</code></strong></td>
                 <td>find the first maximum value in the pattern between the START and END for the working pattern and return its index</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>P.MIN</code></strong></td>
                 <td>find the first minimum value in the pattern between the START and END for the working pattern and return its index</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>P.N</code></strong> <br /><strong><code>P.N x</code></strong></td>
                 <td>get/set the pattern number for the working pattern, default <code>0</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>P.NEXT</code></strong> <br /><strong><code>P.NEXT x</code></strong></td>
                 <td>increment index of working pattern then get/set value</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>P.POP</code></strong></td>
                 <td>return and remove the value from the end of the working pattern (like a stack), destructive to loop length</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>P.PREV</code></strong> <br /><strong><code>P.PREV x</code></strong></td>
                 <td>decrement index of working pattern then get/set value</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>P.PUSH x</code></strong></td>
                 <td>insert value <code>x</code> to the end of the working pattern (like a stack), destructive to loop length</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>P.REV</code></strong></td>
+                <td>reverse the values in the active pattern (between its START and END)</td>
                 </tr>
                 <tr class="odd">
                 <td><strong><code>P.RM x</code></strong></td>
@@ -5988,8 +6213,16 @@
                 <td>return a value randomly selected between the start and the end position</td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>P.ROT n</code></strong></td>
+                <td>rotate the values in the active pattern <code>n</code> steps (between its START and END, negative rotates backward)</td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>P.SEED</code></strong> <br /><strong><code>P.SEED x</code></strong> <br /> <strong><code>P.SD</code></strong></td>
                 <td>get / set the random number generator seed for the <code>P.RND</code> and <code>PN.RND</code> ops</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>P.SHUF</code></strong></td>
+                <td>shuffle the values in active pattern (between its START and END)</td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>P.START</code></strong> <br /><strong><code>P.START x</code></strong></td>
@@ -6060,28 +6293,36 @@
                 <td>get/set pattern length of pattern x. non-destructive to data</td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>PN.MAP x: ...</code></strong></td>
+                <td>apply the 'function' to each value in pattern <code>x</code>, <code>I</code> takes each pattern value</td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>PN.MAX x</code></strong></td>
                 <td>find the first maximum value in the pattern between the START and END for pattern <code>x</code> and return its index</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>PN.MIN x</code></strong></td>
                 <td>find the first minimum value in the pattern between the START and END for pattern <code>x</code> and return its index</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>PN.NEXT x</code></strong> <br /><strong><code>PN.NEXT x y</code></strong></td>
                 <td>increment index of pattern <code>x</code> then get/set value</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>PN.POP x</code></strong></td>
                 <td>return and remove the value from the end of pattern <code>x</code> (like a stack), destructive to loop length</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>PN.PREV x</code></strong> <br /><strong><code>PN.PREV x y</code></strong></td>
                 <td>decrement index of pattern <code>x</code> then get/set value</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>PN.PUSH x y</code></strong></td>
                 <td>insert value <code>y</code> to the end of pattern <code>x</code> (like a stack), destructive to loop length</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>PN.REV x</code></strong></td>
+                <td>reverse the values in pattern <code>x</code></td>
                 </tr>
                 <tr class="odd">
                 <td><strong><code>PN.RM x y</code></strong></td>
@@ -6090,6 +6331,14 @@
                 <tr class="even">
                 <td><strong><code>PN.RND x</code></strong></td>
                 <td>return a value randomly selected between the start and the end position of pattern <code>x</code></td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>PN.ROT x n</code></strong></td>
+                <td>rotate the values in pattern <code>x</code> (between its START and END, negative rotates backward)</td>
+                </tr>
+                <tr class="even">
+                <td><strong><code>PN.SHUF x</code></strong></td>
+                <td>shuffle the values in pattern <code>x</code> (between its START and END)</td>
                 </tr>
                 <tr class="odd">
                 <td><strong><code>PN.START x</code></strong> <br /><strong><code>PN.START x y</code></strong></td>
@@ -6148,88 +6397,96 @@
                 <td>generate a random number between <code>x</code> and <code>y</code> inclusive</td>
                 </tr>
                 <tr class="odd">
+                <td><strong><code>RROT x y</code></strong> <br /> <strong><code>&gt;&gt;&gt;</code></strong></td>
+                <td>circular right shift <code>x</code> by <code>y</code> bits, wrapping around when bits fall off the end</td>
+                </tr>
+                <tr class="even">
                 <td><strong><code>RSH x y</code></strong> <br /> <strong><code>&gt;&gt;</code></strong></td>
                 <td>right shift <code>x</code> by <code>y</code> bits, in effect divide <code>x</code> by <code>2</code> to the power of <code>y</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>S: ...</code></strong></td>
                 <td>Place a command onto the stack</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>S.ALL</code></strong></td>
                 <td>Execute all entries in the stack</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>S.CLR</code></strong></td>
                 <td>Clear all entries in the stack</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>S.L</code></strong></td>
                 <td>Get the length of the stack</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>S.POP</code></strong></td>
                 <td>Execute the most recent entry</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SC.CV x y</code></strong></td>
                 <td>CV target value for the ER-301 virtual output <code>x</code> to value <code>y</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SC.CV.OFF x y</code></strong></td>
                 <td>CV offset added to the ER-301 virtual output <code>x</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SC.CV.SET x</code></strong></td>
                 <td>Set CV value for the ER-301 virtual output <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SC.CV.SLEW x y</code></strong></td>
                 <td>Set the CV slew time for the ER-301 virtual output <code>x</code> in ms</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SC.TR x y</code></strong></td>
                 <td>Set trigger output for the ER-301 virtual output x to y (0-1)</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SC.TR.POL x y</code></strong></td>
                 <td>Set polarity of trigger for the ER-301 virtual output x to y (0-1)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SC.TR.PULSE x</code></strong> <br /> <strong><code>SC.TR.P</code></strong></td>
                 <td>Pulse the ER-301 virtual trigger output <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SC.TR.TIME x y</code></strong></td>
                 <td>Set the pulse time for the ER-301 virtual trigger <code>x</code> to <code>y</code> in ms</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SC.TR.TOG x</code></strong></td>
                 <td>Flip the state for the ER-301 virtual trigger output <code>x</code></td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SCALE a b x y i</code></strong> <br /> <strong><code>SCL</code></strong></td>
                 <td>scale <code>i</code> from range <code>a</code> to <code>b</code> to range <code>x</code> to <code>y</code>, i.e. <code>i * (y - x) / (b - a)</code></td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SCENE</code></strong> <br /><strong><code>SCENE x</code></strong></td>
                 <td>get the current scene number, or load scene <code>x</code> (0-31)</td>
                 </tr>
-                <tr class="even">
+                <tr class="odd">
                 <td><strong><code>SCENE.G x</code></strong></td>
                 <td>load scene <code>x</code> (0-31) without loading grid control states</td>
                 </tr>
-                <tr class="odd">
-                <td><strong><code>SCRIPT</code></strong> <br /><strong><code>SCRIPT x</code></strong> <br /> <strong><code>$</code></strong></td>
-                <td>get current script number, or execute script <code>x</code> (1-8), recursion allowed</td>
-                </tr>
                 <tr class="even">
+                <td><strong><code>SCRIPT</code></strong> <br /><strong><code>SCRIPT x</code></strong> <br /> <strong><code>$</code></strong></td>
+                <td>get current script number, or execute script <code>x</code> (1-10), recursion allowed</td>
+                </tr>
+                <tr class="odd">
                 <td><strong><code>SCRIPT.POL x</code></strong> <br /><strong><code>SCRIPT.POL x p</code></strong> <br /> <strong><code>$.POL</code></strong></td>
                 <td>get script x trigger polarity, or set polarity p (1 rising edge, 2 falling, 3 both)</td>
                 </tr>
-                <tr class="odd">
+                <tr class="even">
                 <td><strong><code>SEED</code></strong> <br /><strong><code>SEED x</code></strong></td>
                 <td>get / set the random number generator seed for all <code>SEED</code> ops</td>
+                </tr>
+                <tr class="odd">
+                <td><strong><code>SGN x</code></strong></td>
+                <td>sign function: 1 for positive, -1 for negative, 0 for 0</td>
                 </tr>
                 <tr class="even">
                 <td><strong><code>SKIP x: ...</code></strong></td>
@@ -6795,22 +7052,43 @@
                 </table>
                 </div>
                 <h1 id="missing-documentation">Missing documentation</h1>
-                <p><code>G.XYP</code>, <code>G.XYP.X</code>, <code>G.XYP.Y</code></p>
+                <p><code>G.XYP</code>, <code>G.XYP.X</code>, <code>G.XYP.Y</code>, <code>SYM.LEFT.ANGLED.x3</code>, <code>SYM.RIGHT.ANGLED.x3</code></p>
                 <h1 id="changelog">Changelog</h1>
+                <h2 id="v3.1.x">v3.1.x</h2>
+                <ul>
+                <li><strong>FIX</strong>: improve DAC latency when using <code>CV</code> ops</li>
+                <li><strong>NEW</strong>: call metro / init with <code>SCRIPT 9</code> / <code>SCRIPT 10</code></li>
+                <li><strong>NEW</strong>: forward (C-f or C-s) and reverse (C-r) search in help mode</li>
+                <li><strong>NEW</strong>: new ops: <code>LROT</code> (alias <code>&lt;&lt;&lt;</code>), <code>RROT</code> (alias <code>&gt;&gt;&gt;</code>)</li>
+                <li><strong>NEW</strong>: <code>LSH</code> and <code>RSH</code> shift the opposite direction when passed a negative shift amount</li>
+                <li><strong>NEW</strong>: new op: <code>SGN</code> (sign of argument)</li>
+                <li><strong>NEW</strong>: new kria remote op: <code>KR.DUR</code></li>
+                <li><strong>NEW</strong>: new op: <code>NR</code> (binary math pattern generator)</li>
+                <li><strong>NEW</strong>: new ops: <code>N.S, N.C, N.CS</code> (use western scales and chords to get values from <code>N</code> table)</li>
+                <li><strong>NEW</strong>: new ops: <code>FADER.SCALE, FADER.CAL.MIN, FADER.CAL.MAX, FADER.CAL.RESET</code> for scaling 16n Faderbank values (aliases <code>FB.S, FB.C.MIN, FB.C.MAX, FB.C.R</code>)</li>
+                <li><strong>NEW</strong>: new Tracker mode keybinding <code>alt-[ ]</code> semitone up, down</li>
+                <li><strong>NEW</strong>: new Tracker mode keybinding <code>ctrl-[ ]</code> fifth up, down</li>
+                <li><strong>NEW</strong>: new Tracker mode keybinding <code>shift-[ ]</code> octave up, down</li>
+                <li><strong>NEW</strong>: new Tracker mode keybinding <code>alt-&lt;0-9&gt;</code> <code>&lt;0-9&gt;</code> semitones up (0=10, 1=11)</li>
+                <li><strong>NEW</strong>: new Tracker mode keybinding <code>shift-alt-&lt;0-9&gt;</code> <code>&lt;0-9&gt;</code> semitones down (0=10, 1=11)</li>
+                <li><strong>FIX</strong>: dim M in edit mode when metro inactive</li>
+                <li><strong>NEW</strong>: new pattern ops: <code>P.SHUF</code>, <code>PN.SHUF</code>, <code>P.REV</code>, <code>PN.REV</code>, <code>P.ROT</code>, <code>PN.ROT</code></li>
+                <li><strong>NEW</strong>: new pattern mods: <code>P.MAP:</code>, <code>PN.MAP x:</code></li>
+                </ul>
                 <h2 id="v3.1.0">v3.1.0</h2>
                 <ul>
-                <li><strong>NEW</strong>: new op: DEVICE.FLIP</li>
+                <li><strong>NEW</strong>: new op: <code>DEVICE.FLIP</code></li>
                 <li><strong>FIX</strong>: <a href="https://github.com/monome/teletype/issues/156">some keyboards losing keystrokes</a></li>
-                <li><strong>NEW</strong>: new op: DEL.X</li>
-                <li><strong>NEW</strong>: new op: DEL.R</li>
+                <li><strong>NEW</strong>: new op: <code>DEL.X</code></li>
+                <li><strong>NEW</strong>: new op: <code>DEL.R</code></li>
                 <li><strong>IMP</strong>: DELAY_SIZE increased to 16 from 8</li>
-                <li><strong>NEW</strong>: new variables: J &amp; K local script variables</li>
+                <li><strong>NEW</strong>: new variables: <code>J</code> &amp; <code>K</code> local script variables</li>
                 <li><strong>FIX</strong>: <a href="https://github.com/monome/teletype/issues/174">metro rate not updated after <code>INIT.SCENE</code></a></li>
-                <li><strong>NEW</strong>: new ops: SEED, R.SEED, TOSS.SEED, DRUNK.SEED, P.SEED, PROB.SEED</li>
-                <li><strong>NEW</strong>: new op: SCENE.G</li>
-                <li><strong>NEW</strong>: new op: SCRIPT.POL, alias $.POL</li>
-                <li><strong>NEW</strong>: new ansible remote ops: ANS.G, ANS.G.P, ANS.G.LED, ANS.A, ANS.A.LED</li>
-                <li><strong>NEW</strong>: new kria remote ops: KR.CUE, KR.PG</li>
+                <li><strong>NEW</strong>: new ops: <code>SEED</code>, <code>R.SEED</code>, <code>TOSS.SEED</code>, <code>DRUNK.SEED</code>, <code>P.SEED</code>, <code>PROB.SEED</code></li>
+                <li><strong>NEW</strong>: new op: <code>SCENE.G</code></li>
+                <li><strong>NEW</strong>: new op: <code>SCRIPT.POL</code>, alias <code>$.POL</code></li>
+                <li><strong>NEW</strong>: new ansible remote ops: <code>ANS.G</code>, <code>ANS.G.P</code>, <code>ANS.G.LED</code>, <code>ANS.A</code>, <code>ANS.A.LED</code></li>
+                <li><strong>NEW</strong>: new kria remote ops: <code>KR.CUE</code>, <code>KR.PG</code></li>
                 </ul>
                 <h2 id="v3.0.0">v3.0.0</h2>
                 <ul>
@@ -6822,11 +7100,11 @@
                 <li><strong>NEW</strong>: i2c support for 16n Faderbank</li>
                 <li><strong>NEW</strong>: i2c support for Matrixarchate</li>
                 <li><strong>NEW</strong>: i2c support for W/</li>
-                <li><strong>NEW</strong>: new op: ?</li>
-                <li><strong>NEW</strong>: new ops: P.MIN, PN.MIN, P.MAX, PN.MAX, P.RND, PN.RND, P.+, PN.+, P.-, PN.-. P.+W, PN.+W, P.-W, PN.-W</li>
-                <li><strong>NEW</strong>: new Telex ops: TO.CV.CALIB, TO.ENV</li>
-                <li><strong>NEW</strong>: new Kria ops: KR.CV, KR.MUTE, KR.TMUTE, KR.CLK, ME.CV</li>
-                <li><strong>NEW</strong>: new aliases: $, RND, RRND, WRP, SCL</li>
+                <li><strong>NEW</strong>: new op: <code>?</code></li>
+                <li><strong>NEW</strong>: new ops: <code>P.MIN</code>, <code>PN.MIN</code>, <code>P.MAX</code>, <code>PN.MAX</code>, <code>P.RND</code>, <code>PN.RND</code>, <code>P.+</code>, <code>PN.+</code>, <code>P.-</code>, <code>PN.-</code>. <code>P.+W</code>, <code>PN.+W</code>, <code>P.-W</code>, <code>PN.-W</code></li>
+                <li><strong>NEW</strong>: new Telex ops: <code>TO.CV.CALIB</code>, <code>TO.ENV</code></li>
+                <li><strong>NEW</strong>: new Kria ops: <code>KR.CV</code>, <code>KR.MUTE</code>, <code>KR.TMUTE</code>, <code>KR.CLK</code>, <code>ME.CV</code></li>
+                <li><strong>NEW</strong>: new aliases: <code>$</code>, <code>RND</code>, <code>RRND</code>, <code>WRP</code>, <code>SCL</code></li>
                 <li><strong>NEW</strong>: telex, ansible, just friends, w/ added to the help screen</li>
                 <li><strong>FIX</strong>: i2c initialization delayed to account for ER-301 bootup</li>
                 <li><strong>FIX</strong>: last screen saved to flash</li>
@@ -6842,15 +7120,15 @@
                 <li><strong>FIX</strong>: <a href="https://github.com/monome/teletype/issues/144"><code>TIME</code> and <code>LAST</code> are now 1ms accurate</a></li>
                 <li><strong>FIX</strong>: <a href="https://github.com/monome/teletype/issues/143"><code>RAND</code> / <code>RRAND</code> will properly work with large range values</a></li>
                 <li><strong>FIX</strong>: <a href="https://github.com/monome/teletype/issues/148"><code>L .. 32767</code> won't freeze</a></li>
-                <li><strong>FIX</strong>: I now accessible to child SCRIPTS</li>
+                <li><strong>FIX</strong>: <code>I</code> now accessible to child SCRIPTS</li>
                 </ul>
                 <h2 id="v2.2">v2.2</h2>
                 <ul>
                 <li><strong>NEW</strong>: added a cheat sheet PDF</li>
-                <li><strong>NEW</strong>: new bitwise ops: &amp;, |, ^, ~, BSET, BCLR, BGET</li>
+                <li><strong>NEW</strong>: new bitwise ops: <code>&amp;</code>, <code>|</code>, <code>^</code>, <code>~</code>, <code>BSET</code>, <code>BCLR</code>, <code>BGET</code></li>
                 <li><strong>NEW</strong>: new ops <code>PARAM.SCALE min max</code> and <code>IN.SCALE min max</code> to add static scaling to inputs</li>
                 <li><strong>NEW</strong>: blanking screensaver after 90 minutes of keyboard inactivity, any key to wake</li>
-                <li><strong>NEW</strong>: new op: CHAOS chaotic sequence generator. Control with CHAOS.ALG and CHAOS.R</li>
+                <li><strong>NEW</strong>: new op: <code>CHAOS</code> chaotic sequence generator. Control with <code>CHAOS.ALG</code> and <code>CHAOS.R</code></li>
                 <li><strong>NEW</strong>: new op family: <code>INIT</code>, to clear device state</li>
                 <li><strong>NEW</strong>: new ops: <code>R</code>, <code>R.MIN</code>, <code>R.MAX</code> programmable RNG</li>
                 <li><strong>IMP</strong>: profiling code (optional, dev feature)</li>
@@ -6882,7 +7160,7 @@
                 <li><strong>OLD</strong>: ctrl-F1 to F8 mute/unmute scripts.</li>
                 <li><strong>NEW</strong>: ctrl-F9 enables/disables METRO.</li>
                 <li><strong>FIX</strong>: recursive delay fix. Now you can <code>1: DEL 500: SCRIPT 1</code> for temporal recursion.</li>
-                <li><strong>FIX</strong>: KILL now clears TR output as well as disabling the METRO script.</li>
+                <li><strong>FIX</strong>: <code>KILL</code> now clears TR output as well as disabling the METRO script.</li>
                 <li><strong>FIX</strong>: if / else conditions no longer transcend their script</li>
                 <li><strong>IMP</strong>: functional exectuion stack for <code>SCRIPT</code> operations</li>
                 </ul>
@@ -6911,7 +7189,7 @@
                 <li><strong>IMP</strong>: <code>AND</code> and <code>OR</code> now work as boolean logic, rather than bitwise, <code>XOR</code> is an alias for <code>NE</code></li>
                 <li><strong>FIX</strong>: divide by zero errors now explicitly return a 0 (e.g. <code>DIV 5 0</code> now returns 0 instead of -1), previously the behaviour was undefined and would crash the simulator</li>
                 <li><strong>FIX</strong>: numerous crashing bugs with text entry</li>
-                <li><strong>FIX</strong>: <code>i2c</code> bus crashes under high <code>M</code> times with external triggers</li>
+                <li><strong>FIX</strong>: i2c bus crashes under high <code>M</code> times with external triggers</li>
                 <li><strong>FIX</strong>: <code>P.I</code> and <code>PN.I</code> no longer set values longer than allowed</li>
                 <li><strong>FIX</strong>: <code>VV</code> works correctly with negative values</li>
                 </ul>
@@ -6991,7 +7269,7 @@
                 </ol>
                 </section>
 
-                
+
             </div>
         </div>
         <script>
@@ -7055,17 +7333,17 @@
                                 navElements[j]
                                     .classList
                                     .add("NavigationArea-navLi--closed");
-                    } else if (!parentHrefClicked && 
-                        hrefClicked && 
+                    } else if (!parentHrefClicked &&
+                        hrefClicked &&
                         navElements[j]
                             .classList
-                            .contains("NavigationArea-navLi--secondary") && 
+                            .contains("NavigationArea-navLi--secondary") &&
                         navElements[j]
                             .getAttribute("active-parent-anchor") !== hrefClicked) {
                                 navElements[j]
                                     .classList
                                     .add("NavigationArea-navLi--closed");
-                    } else if (parentHrefClicked && 
+                    } else if (parentHrefClicked &&
                         navElements[j]
                             .getAttribute("active-parent-anchor") === parentHrefClicked) {
                                 navElements[j]
@@ -7156,7 +7434,7 @@
                     }
                 };
 
-                // for phone-size screens, navigation pane should 
+                // for phone-size screens, navigation pane should
                 // hide as soon as a nav element is clicked
                 if (window.innerWidth < 700) {
                     hidden = false;


### PR DESCRIPTION
I manually edited the version number at the top of the HTML output, the generation process relies on the git tag somehow and I can't figure out right now how to correct this in the PDF manual.