### PR TITLE
druid: on win, use python -m pip since pip3 is not on PATH

### DIFF
--- a/ansible/advanced.md
+++ b/ansible/advanced.md
@@ -15,8 +15,8 @@ Ansible can be used as a leader device for the [ii](/docs/modular/ii)
 bus, controlling one or more follower modules using trigger and CV
 information sent from Ansible. Since Ansible is not wired to supply
 power to the ii bus, another leader module or a powered busboard is
-required to use Ansible as a leader. Having [/docs/crow](Crow) or
-[/docs/teletype](Teletype) connected to the same ii bus is sufficient.
+required to use Ansible as a leader. Having [Crow](/docs/crow) or
+[Teletype](docs/teletype) connected to the same ii bus is sufficient.
 
 When Ansible is acting as a ii leader, it can no longer receive ii
 commands from other leaders like Teletype or Crow. Note also that
@@ -234,4 +234,3 @@ You can leave the tuning page to experiment with your tuning on other
 Grid apps, but note that tuning changes are not saved to flash until
 you explicitly save them using one of the rightmost keys on the third
 row up of the tuning page.
-

--- a/crow/druid.md
+++ b/crow/druid.md
@@ -61,6 +61,12 @@ sudo pip3 install monome-druid
 
 Now druid should be ready to use, you might need to close and reopen the terminal to get access to it.
 
+To update when there's a new [release](https://github.com/monome/druid/releases), use
+
+```
+pip3 install --upgrade monome-druid
+```
+
 ### install druid on Windows
 
 In PowerShell, execute:
@@ -72,13 +78,19 @@ python -m pip install pyserial asyncio prompt_toolkit
 Then:
 
 ```
-pip3 install --upgrade setuptools
+python -m pip install --upgrade setuptools
 ```
 
 Finally:
 
 ```
-pip3 install monome-druid
+python -m pip install monome-druid
+```
+
+To update when there's a new [release](https://github.com/monome/druid/releases), use
+
+```
+python -m pip install --upgrade monome-druid
 ```
 
 #### Windows errors


### PR DESCRIPTION
Python on Windows doesn't even have `pip` on the path, for whatever reason they've always put python in `...\PythonVV\` and pip in `...\PythonVV\Scripts\` and never added the latter to the path automatically.

I also spotted a couple links with backwards markdown syntax in the Ansible docs.