### PR TITLE
druid installation: suggest CDC driver on windows 7

### DIFF
--- a/crow/druid.md
+++ b/crow/druid.md
@@ -105,6 +105,8 @@ On the dialogue that appears, click the Environment Variables button. In the "Us
 
 Click OK until all the dialogue boxes are gone.
 
+On Windows 7, druid may be unable to connect with crow. Try using Zadig (instructions [here](/docs/crow/update/#windows)) to install the "USB Serial (CDC)" driver instead of the "WinUSB" driver.
+
 ## loading druid
 
 Let's load up `druid` to test if everything works as expected. With crow connected to your device with USB and your modular case turned on, execute:

--- a/crow/update.md
+++ b/crow/update.md
@@ -132,3 +132,5 @@ If you get an error:  `Cannot open DFU device 0483:df11`, this means that your c
 - to the right of the green arrow, you should have `WinUSB (v6.1.7600.16385)` (if you don't, please select it)
 - click the Replace Driver button and wait a few minutes for the process to complete
 - re-attempt [flashing the update](#flashing-the-update)
+
+On Windows 7, you may need to use the "USB Serial (CDC)" driver instead of WinUSB.


### PR DESCRIPTION
Forum user chrlz couldn't get druid or dfu-util to work on Windows 7 even though the OS was reporting that crow was connected. Turns out that Windows 7 wants the "USB Serial (CDC)" driver available in Zadig rather than WinUSB -- this driver allows communicating with crow in both normal operation and bootloader mode. Discussion was [here](https://llllllll.co/t/crow-help-druid/25864/222) and in PM.