### PR TITLE
update #network-connect anchor heading

### DIFF
--- a/norns/play.md
+++ b/norns/play.md
@@ -104,7 +104,7 @@ If you wish to clear a currently running script, highlight SELECT + hold K1. You
 #### SYSTEM
 
 - DEVICES - This is a list of connected USB hardware with their associated port number. Most scripts address port 1. See [norns study 4](https://monome.org/docs/norns/study-4/) for a scripting guide to multiple ports. This section lets you re-assign connected devices to specific ports.
-- WIFI - Networking settings. Requires USB WIFI interface. See [CONNECT](#connect).
+- WIFI - Networking settings. Requires USB WIFI interface. See [NETWORK CONNECT](#network-connect).
 - RESET - Quickly resets the audio system and resets current configuration data to a default state, restoring audio levels to maximum and clearing the currently loaded script.
 - UPDATE - Checks for updates. Internet connection required. See [UPDATE](#update).
 


### PR DESCRIPTION
Noticed that the "CONNECT" link was incorrect while reading the docs. Updated it to "NETWORK CONNECT" linking to the `#network-connect` section