### PR TITLE
aleph: fix link from index to development

### DIFF
--- a/aleph/index.md
+++ b/aleph/index.md
@@ -13,4 +13,4 @@ has_toc: false
 * [Information](https://monome.org/aleph) -- Details about Aleph sound computer.
 * [Reference](reference) -- Information about Bees, modules and applications.
 * [Tutorial](tutorial-0) -- Introduction to using the Aleph.
-* [Development](dev) -- Guides for creating your own modules, applications, and Bees operators.
+* [Development](development) -- Guides for creating your own modules, applications, and Bees operators.


### PR DESCRIPTION
Other links to /development seem OK, just the one from the aleph front page was broken.