### PR TITLE
ansible / tt: mention that USB hubs are not supported

### DIFF
--- a/ansible/index.md
+++ b/ansible/index.md
@@ -75,7 +75,7 @@ This documentation documents firmware version **3.0.0**. Changelogs and binaries
 
 Output and input functionality vary according to which application is running.
 
-Applications are determined by which USB device is plugged in. For example, when you plug in a Grid after a firmware update, it will be running Kria. Hold the MODE key (next to the USB port) to switch to Meadowphysics; push it again to switch to Earthsea. Ansible will remember which application you were last running between power-ups.
+Applications are determined by which USB device is plugged in. For example, when you plug in a Grid after a firmware update, it will be running Kria. Hold the MODE key (next to the USB port) to switch to Meadowphysics; push it again to switch to Earthsea. Ansible will remember which application you were last running between power-ups. NOTE: USB hubs do not work with Ansible.
 
 Unplugging the Grid and plugging an Arc will change to Levels.
 

--- a/teletype/index.md
+++ b/teletype/index.md
@@ -46,6 +46,10 @@ Secure the module with the four included screws, hiding under the tape in the bo
 
 If you wish Teletype to communicate with Ansible or other modules with [ii](/docs/modular/ii), you will need to attach an ii cable (not included, but DIY'able [here](https://www.adafruit.com/product/1950)) as outlined in the [ii Communication](/docs/modular/iiheader/#connecting-the-trilogy) page. Teletype can also connect to a world of other [i2c-capable devices](https://llllllll.co/t/a-users-guide-to-i2c/19219). If your Teletype has a green circuit board, it can support 2 direct ii/i2c connections. If it has a black circuit board (Dec 2018 revision), it can support 4 direct ii/i2c connections.
 
+### Keyboard
+
+Teletype cannot use a USB keyboard if it has an internal USB hub, and does not work with USB hubs in general. Otherwise most keyboards should work, but keep in mind that backlit keyboards etc. are drawing power from Teletype, so you may wish to use external USB power. Teletype assumes the keyboard layout is US-ANSI. For more discussion, see [lines](https://llllllll.co/t/alternative-teletype-keyboard-recommendations-mechanical-wireless-etc/5859).
+
 ### Firmware
 
 **[Firmware updates](/docs/modular/update) may be available. The currently installed firmware version is displayed at startup.**


### PR DESCRIPTION
In particular some keyboards won't work because they have built in USB hubs. Also mention Teletype keyboard layout / power considerations.