### PR TITLE
Crow: unset output scale mapping

### DIFF
--- a/crow/reference.md
+++ b/crow/reference.md
@@ -144,6 +144,9 @@ output[n].scale( {scale}, temperament, scaling )
   --        use the empty table {} for chromatic scale
   -- temperament: how many notes in a scale, default 12 (ie 12TET)
   -- scaling: volts per octave, default to 1.0, but use eg. 1.2 for buchla systems
+
+-- deactivate any active scaling with the 'none' argument
+output[n].scale( 'none' )
 ```
 
 ### actions


### PR DESCRIPTION
Simply adds a reference to otherwise undocumented `output[n].scale('none')` for deactivating a currently set output scale mapping.