### PR TITLE
Fix network connect links

### DIFF
--- a/norns/help.md
+++ b/norns/help.md
@@ -80,7 +80,7 @@ Many thanks to `@mutedial` for [compiling replacement steps](https://llllllll.co
 
 _nb. If you are not actively using the wifi nub, it's best not to keep it plugged in. It uses a lot of power, draining both battery and system resources._
 
-If you are consistently unable to connect your norns to wifi through the ['Connect' steps outlined here](../play/#connect), please perform the following steps:
+If you are consistently unable to connect your norns to wifi through the ['Network Connect' steps outlined here](../play/#network-connect), please perform the following steps:
 
 1. Try getting very close to your wifi router. Bad signal can make it seem nonfunctional.
 
@@ -133,7 +133,7 @@ Press K1 to toggle from PLAY to HOME. Highlight `SELECT` and hold K1 -- you'll s
 
 Supercollider fails to load if you have multiple copies of the same class, which are commonly contained in duplicate `.sc` files inside of `dust` (the parent folder for the projects installed on norns).
 
-To typically solve this, [connect](../play/#connect) via wifi and open [maiden](../maiden). Type `;restart` into the maiden _matron_ REPL at the bottom (the `>>` prompt).
+To typically solve this, [connect](../play/#network-connect) via wifi and open [maiden](../maiden). Type `;restart` into the maiden _matron_ REPL at the bottom (the `>>` prompt).
 
 This will restart the audio components and output their logs. If there's a duplicate class an error message like the following will be shown:
 

--- a/norns/sftp.md
+++ b/norns/sftp.md
@@ -23,7 +23,7 @@ Be careful when editing files on Norns.  If you delete files that Norns needs to
 
 Alternatives to Cyberduck include Transmit for macOS and FileZilla for macOS, windows and linux.  While the screens will be different, the goal is the same, (to connect to Norns over the IP adress provided using SFTP/port 22).
 
-1. If not already, start up Norns.  Navigate to SYSTEM / WIFI.  You can either use Norns in HOTSPOT mode, or by connecting to the same NETWORK that the computer you'll be downloading the SFTP client to is on. See the [connect docs](../play/#connect) for more information about WIFI setup.
+1. If not already, start up Norns.  Navigate to SYSTEM / WIFI.  You can either use Norns in HOTSPOT mode, or by connecting to the same NETWORK that the computer you'll be downloading the SFTP client to is on. See the [network connect docs](../play/#network-connect) for more information about WIFI setup.
 
 2. Download Cyberduck.  You can find direct package installation for free from Cyberduck's website on the [changelog](https://cyberduck.io/changelog/) page.
 


### PR DESCRIPTION
The relative url to the Network Connect section of the norns play page was broken. I updated all instances I could find.