### PR TITLE
Update fileshare.md

### DIFF
--- a/norns/fileshare.md
+++ b/norns/fileshare.md
@@ -44,7 +44,7 @@ To use SMB network sharing on Windows 10, navigate to Control Panel > Programs >
 
 Reboot.
 
-The norns.local file tree should be available at \\norns.local
+The norns.local file tree should be available at `\\norns.local`
 
 ## file tree
 


### PR DESCRIPTION
typo. `\\norns.local` needs to be marked up as code to be rendered correctly in the output