### PR TITLE
tutorials on compiling and extending norns

### DIFF
--- a/norns/compiling.md
+++ b/norns/compiling.md
@@ -13,7 +13,7 @@ by building the latest changes made to the code between official
 releases, either to try new features or get bug fixes as soon as
 possible. or you might want to make your own modifications to the
 software or try patches made by community members (for more details,
-see the [/norns/extending](extending norns) page).
+see the [extending norns](/norns/extending) page).
 
 norns (the sound computer) comes with everything you need to edit and
 recompile norns (the software suite). this page gives a quick guide on
@@ -61,21 +61,20 @@ Linux norns 4.19.127-16-gb1425b1 #1 SMP PREEMPT Mon Oct 26 05:39:00 UTC 2020 arm
 |_|_|___|_| |_|_|___| monome.org/norns
 
 we@norns.local:~$ cd norns
-we@norns.local:~/norns$ 
+we@norns.local:~/norns$
 ```
 
 this directory (`/home/we/norns`) contains all the source code for
-norns -- it's a checkout of the https://github.com/monome/norns git
-repository. it's also sort of the main directory for norns system
+norns -- it's a checkout of the [git repository](https://github.com/monome/norns). it's also sort of the main directory for norns system
 files, as opposed to user files like scripts and tape recordings,
 which are in `/home/we/dust`. that includes the executable files for
 the core norns C/C++ programs including `matron` and `crone`. source
-code for `maiden` lives [https://github.com/monome/maiden](elsewhere).
+code for `maiden` lives [elsewhere](https://github.com/monome/maiden)
 
 the git repository `/home/we/norns` is set up to point at the main
-norns repo on github. by default the version on github is nicknamed
-`origin`. to pull the latest changes on github down and merge them
-into the local copy, we run:
+norns repo on github. by default the copy of the code that's on the
+monome github is nicknamed `origin`. to pull the latest changes on
+github down and merge them into the local copy, we run:
 
 ```bash
 we@norns:~/norns$ git pull origin main
@@ -91,14 +90,13 @@ yet, this will show you a summary of changes as well.
 we also need to make sure that the submodules are all up to
 date. submodules are basically git repos within a git repo that help
 norns track dependencies on other projects, notably the main
-[https://github.com/monome/softcut](softcut library) and ableton link
+[softcut library](https://github.com/monome/softcut) and ableton link
 support. run:
 
 ```bash
 we@norns:~/norns$ git submodule update --init --recursive
-git submodule update --init --recursive
 Submodule path 'crone/softcut': checked out '7cce02a6f5b58a9c46bd022bd7b572e2b3218dae'
-we@norns:~/norns$ 
+we@norns:~/norns$
 ```
 
 ## compiling with waf
@@ -111,22 +109,22 @@ run:
 
 ```bash
 we@norns.local:~/norns$ ./waf configure
-Setting top to                           : /home/we/norns 
-Setting out to                           : /home/we/norns/build 
-Checking for 'gcc' (C compiler)          : /usr/bin/gcc 
-Checking for 'g++' (C++ compiler)        : /usr/bin/g++ 
+Setting top to                           : /home/we/norns
+Setting out to                           : /home/we/norns/build
+Checking for 'gcc' (C compiler)          : /usr/bin/gcc
+Checking for 'g++' (C++ compiler)        : /usr/bin/g++
 ...
-Checking for libmonome                   : yes 
-Checking for supercollider               : yes 
-Checking for program 'dpkg-architecture' : /usr/bin/dpkg-architecture 
-Checking boost includes                  : 1.62.0 
+Checking for libmonome                   : yes
+Checking for supercollider               : yes
+Checking for program 'dpkg-architecture' : /usr/bin/dpkg-architecture
+Checking boost includes                  : 1.62.0
 'configure' finished successfully (2.727s)
 we@norns.local:~/norns$
 ```
 
 if there are missing dependencies, you may need to install them using
 `apt-get`. as of the current norns version with the latest image
-(201029) all dependencies should already be installed.
+(201023 and above) all dependencies should already be installed.
 
 assuming that you get `'configure' finished successfully` we should be
 already to compile:

--- a/norns/compiling.md
+++ b/norns/compiling.md
@@ -1,0 +1,154 @@
+---
+layout: default
+nav_exclude: true
+permalink: /norns/compiling/
+---
+
+# compiling norns
+
+while norns is designed for easily updating to the latest software
+release, there are several reasons you might wish to recompile the
+norns programs yourself. you might want to keep on the bleeding edge
+by building the latest changes made to the code between official
+releases, either to try new features or get bug fixes as soon as
+possible. or you might want to make your own modifications to the
+software or try patches made by community members (for more details,
+see the [/norns/extending](extending norns) page).
+
+norns (the sound computer) comes with everything you need to edit and
+recompile norns (the software suite). this page gives a quick guide on
+how to get the latest changes and recompile.  if you are interested in
+modifying the norns platform or knowing what's currently in the works,
+take a look at the [github
+issues](https://github.com/monome/norns/issues) to see the list of
+open bugs and feature requests. new release builds are packaged up and
+released every few months or so. note that any contributions to the
+norns system will generally not be widely available for use in scripts
+until an official release comes out, since typically users update
+norns through the SYSTEM > UPDATE menu option.
+
+throughout this tutorial we will be running command line programs in a
+shell session. the entire output printed to the terminal will be
+included, possibly using a `...` to skip long sections we don't need
+to see. in particular, the shell prompt `$` will be shown, possibly
+including username and server information. what this means is when the
+instructions say something like:
+
+- we run:
+  ```bash
+  we@norns.local:~/norns$ ls
+  build            crone.sh     matron.sh         resources    version.mk
+  ...
+  ```
+
+then the only part that you actually type in is `ls`, the rest of
+what's shown in the docs is just the prompt that the terminal shows
+you when waiting for input. also, the line(s) with the prompt is the
+only line we type into -- the other output (`build crone.sh ...`) is
+output from the `ls` program.
+
+## get up to date
+
+open a terminal and connect to norns via [SSH](/norns/play/#ssh). then
+go to the `norns` directory using `cd norns`.
+
+```bash
+$ ssh we@norns.local
+we@norns.local's password:
+Linux norns 4.19.127-16-gb1425b1 #1 SMP PREEMPT Mon Oct 26 05:39:00 UTC 2020 armv7l
+ ___ ___ ___ ___ ___
+|   | . |  _|   |_ -|
+|_|_|___|_| |_|_|___| monome.org/norns
+
+we@norns.local:~$ cd norns
+we@norns.local:~/norns$ 
+```
+
+this directory (`/home/we/norns`) contains all the source code for
+norns -- it's a checkout of the https://github.com/monome/norns git
+repository. it's also sort of the main directory for norns system
+files, as opposed to user files like scripts and tape recordings,
+which are in `/home/we/dust`. that includes the executable files for
+the core norns C/C++ programs including `matron` and `crone`. source
+code for `maiden` lives [https://github.com/monome/maiden](elsewhere).
+
+the git repository `/home/we/norns` is set up to point at the main
+norns repo on github. by default the version on github is nicknamed
+`origin`. to pull the latest changes on github down and merge them
+into the local copy, we run:
+
+```bash
+we@norns:~/norns$ git pull origin main
+From https://github.com/monome/norns
+ * branch            main       -> FETCH_HEAD
+Already up-to-date.
+we@norns:~/norns$
+```
+
+if there are a bunch of changes up on github that haven't been pulled
+yet, this will show you a summary of changes as well.
+
+we also need to make sure that the submodules are all up to
+date. submodules are basically git repos within a git repo that help
+norns track dependencies on other projects, notably the main
+[https://github.com/monome/softcut](softcut library) and ableton link
+support. run:
+
+```bash
+we@norns:~/norns$ git submodule update --init --recursive
+git submodule update --init --recursive
+Submodule path 'crone/softcut': checked out '7cce02a6f5b58a9c46bd022bd7b572e2b3218dae'
+we@norns:~/norns$ 
+```
+
+## compiling with waf
+
+all the norns C / C++ programs are built with a build tool called
+[`waf`](https://waf.io). first we need to check that all dependencies
+are installed and set up the build environment. generally you only
+need to do this if a new dependency is added, which is fairly seldom.
+run:
+
+```bash
+we@norns.local:~/norns$ ./waf configure
+Setting top to                           : /home/we/norns 
+Setting out to                           : /home/we/norns/build 
+Checking for 'gcc' (C compiler)          : /usr/bin/gcc 
+Checking for 'g++' (C++ compiler)        : /usr/bin/g++ 
+...
+Checking for libmonome                   : yes 
+Checking for supercollider               : yes 
+Checking for program 'dpkg-architecture' : /usr/bin/dpkg-architecture 
+Checking boost includes                  : 1.62.0 
+'configure' finished successfully (2.727s)
+we@norns.local:~/norns$
+```
+
+if there are missing dependencies, you may need to install them using
+`apt-get`. as of the current norns version with the latest image
+(201029) all dependencies should already be installed.
+
+assuming that you get `'configure' finished successfully` we should be
+already to compile:
+
+```bash
+we@norns.local:~/norns$ ./waf -j 1
+Waf: Entering directory `/home/we/norns/build'
+...
+Waf: Leaving directory `/home/we/norns/build'
+'build' finished successfully
+```
+
+each file that has been changed since you last compiled will be
+listed. the `-j 1` option instructs norns to use only one thread --
+using all the CPU for recompiling (the default) can make norns
+unresponsive.
+
+## restart
+
+assuming you get `'build' finished successfully`, you've now rebuilt
+norns and are ready to restart. the easiest way to do that is just to
+put norns to SLEEP as usual.
+
+to continue from here and learn how to make your own changes to the
+norns code, see [extending norns](/norns/extending).

--- a/norns/extending.md
+++ b/norns/extending.md
@@ -1,0 +1,258 @@
+---
+layout: default
+nav_exclude: true
+permalink: /norns/extending/
+---
+
+# extending norns
+
+sometimes desired functionality is impossible or inefficient to
+achieve in a norns script, but can become possible by modifying the
+source code of the norns system itself. norns (the sound computer)
+comes with everything you need to edit and recompile norns (the
+software suite), allowing you to add new functions to the core lua
+library and/or change how lua interacts with the hardware and the
+audio DSP. this tutorial will demonstrate how to extend norns by
+adding a new routine to the `screen` graphics library. if you make
+some additions or enhancements you'd like to see in the main norns
+code base, please send a [pull request on
+github](https://github.com/monome/norns/pulls)!
+
+this tutorial assumes you've already figured out how to [compile
+norns](/norns/compiling), and also assumes some familiarity with the C
+programming language.
+
+## where are we going with this?
+
+the `screen` library on norns allows drawing a lot of interesting
+graphics using a shape-based set of drawing functions, but
+occasionally we'd like to get the values of pixels that have already
+been drawn to the screen. we're going to implement a `screen.peek(x,
+y, w, h)` lua function that allows determining the values of pixels in
+a certain area of the screen.
+
+### detour: norns programs
+
+during normal operation, a few different programs run on norns all at
+once.
+
+- [*`maiden`*](https://github.com/monome/maiden): a web server that
+   serves a javascript app implementing an in-browser editor / IDE for
+   writing and installing norns scripts. we won't be talking about
+   maiden much in this tutorial, making changes to maiden works
+   somewhat differently and it's pretty independent from everything
+   else. the maiden browser app communicates with `matron` and
+   `sclang` (the supercollider interpreter) via websockets. run
+   `maiden help` in an SSH session to see available options.
+
+- *`maiden-repl`* meanwhile is a C program (built with ncurses) that
+   can make a websocket connection to `matron` or `sclang`. this
+   allows you to access a REPL from an SSH session into norns. you can
+   access this on norns by running `maiden repl` in an SSH session.
+
+- *`matron`*: the "front of house" application you typically interact
+   with when using norns. evaluates lua code, including user scripts
+   and the REPL. draws to the screen and checks for key / encoder
+   input. handles device detection and MIDI. sends control messages to
+   the audio parts. this will be the focus of our discussion today.
+
+- *`crone`*: the audio stuff manager. handles OSC messages for mixing,
+   tape, and softcut. you may also wish to add other commands here for
+   e.g. adding functionality to softcut but this is a bit of a
+   different topic.
+
+- *`ws-wrapper`*: `matron` and `sclang` just interact with stdin /
+   stdout (reading from / writing to the terminal), they can't
+   communicate with a remote application like `maiden` on their
+   own. `ws-wrapper` is a utility program that creates a websocket
+   server and passes websocket messages to and from the wrapped
+   program.
+
+`crone`, `maiden`, and `ws-wrapper`'d versions of `matron` and
+`sclang` are started on bootup by systemd services defined in
+`/etc/systemd/system`. together these make up the norns software
+stack.
+
+to make sure we've compiled the current code, run `waf`:
+
+```bash
+we@norns.local:~/norns$ ./waf -j 1
+Waf: Entering directory `/home/we/norns/build'
+...
+Waf: Leaving directory `/home/we/norns/build'
+'build' finished successfully
+```
+
+at the moment, we haven't changed anything, so there's no need to
+restart anything. but after recompiling, for changes to take effect
+you'll also need to restart any modified programs or just restart
+norns entirely. you can restart maiden in a couple of different ways,
+including putting the `;restart` command in the maiden repl or
+running, for instance:
+
+```bash
+we@norns.local:~/norns$ systemctl restart norns-matron.service
+```
+
+or by SLEEPing or RESETing the norns system.
+
+this is the build cycle we'll be using to test changes made to matron --
+run `./waf` to rebuild, then restart matron.
+
+
+## lua / C interface
+
+all the main norns objects available to lua (`grid`, `screen`, `midi`,
+...) are implemented in a lua files in the `/home/we/norns/lua/core`
+folder. internally these libraries are able to interact with matron's
+C code using functions on the `_norns` table. while these functions
+are callable from lua, they are in fact implemented in C, and their
+implementations can be found in
+`norns/matron/src/weaver.c`. specifically the `w_init` function
+contains many lines like this:
+
+```c
+    // register screen funcs
+    lua_register_norns("screen_update", &_screen_update);
+    lua_register_norns("screen_save", &_screen_save);
+    lua_register_norns("screen_restore", &_screen_restore);
+```
+
+adding a new entry here will make another C function accessible from
+lua by adding a new value to the `_norns` table. all such functions
+have the same signature (argument and return value types). we need to
+add a function declaration (toward the top of the file):
+
+```c
+static int _screen_peek(lua_State *l);
+```
+
+we also add a function definition, down with the other `_screen_`
+function definitions. these need to get whatever arguments were passed
+from lua, do some work, and possibly give a result back. we also
+include specially formatted comments that provide documentation for
+the arguments these functions expect. for a function that returns a
+value, we need to tell lua we left 1 value on the stack by returning
+1. for more info, see [this page](https://www.lua.org/pil/24.2.html)
+about using the lua stack.
+
+```c
+/***
+ * screen: peek
+ * @function s_peek
+ * @tparam integer x screen x position (0-127) 
+ * @tparam integer y screen y position (0-63)
+ * @tparam integer w rectangle width to grab
+ * @tparam integer h rectangle height to grab
+ */
+int _screen_peek(lua_State *l) {
+    lua_check_num_args(4);
+    int x = luaL_checkinteger(l, 1);
+    int y = luaL_checkinteger(l, 2);
+    int w = luaL_checkinteger(l, 3);
+    int h = luaL_checkinteger(l, 4);
+    lua_settop(l, 0);
+    if ((x >= 0) && (x <= 127)
+     && (y >= 0) && (y <= 63)
+     && (w > 0)
+     && (h > 0)) {
+        uint8_t* buf = screen_peek(x, y, &w, &h);
+        if (buf) {
+            lua_pushlstring(l, buf, w * h);
+            free(buf);
+            return 1;
+        }
+    } 
+    return 0;
+}
+```
+
+*tip:* to print something out for debugging in matron, you generally
+ do it like this:
+
+```c
+fprintf(stderr, "some value: %d\n", 1234);
+```
+
+we'll also need to modify the `screen` lua library to expose the new
+function. in `norns/lua/core/screen.lua`. it's easier to hand in
+default values here and so on.
+
+```lua
+--- get a rectangle of screen content.
+-- @tparam number x x position
+-- @tparam number y y position
+-- @tparam number w width, default 1
+-- @tparam number h height, default 1
+Screen.peek = function(x, y, w, h)
+  return _norns.screen_peek(x, y, w or 1, h or 1)
+end
+```
+
+that takes care of handing values back and forth between lua and
+C. then we need to implement the `screen_peek` function.
+
+
+## the screen buffer
+
+first we need to declare the signature for our `screen_peek` function
+in the `screen.h` header file so it can be used from `weaver.c`. in `norns/matron/src/hardware/screen.h`:
+
+```c
+extern char *screen_peek(int x, int y, int *w, int *h);
+```
+
+then in `norns/matron/src/hardware/screen.c` we'll write the
+definition. the details of this specific example function aren't
+necessary to understand, other C extensions could be much simpler or
+totally different from this.
+
+```c
+uint8_t *screen_peek(int x, int y, int *w, int *h) {
+    // this is a macro that bails out if the screen
+    // hasn't been set up yet
+    CHECK_CRR
+    // need to ensure that the requested width and height
+    // are in bounds
+    *w = (*w <= (128 - x)) ? (*w) : (128 - x);
+    *h = (*h <= (64 - y))  ? (*h) : (64 - y);
+    // allocate a big enough destination buffer
+    uint8_t *buf = malloc(*w * *h);
+    if (!buf) {
+        return NULL;
+    }
+    // finish any pending drawing
+    cairo_surface_flush(surface);
+    // get the raw pixel data for the screen
+    uint32_t *data = (uint32_t *)cairo_image_surface_get_data(surface);
+    if (!data) {
+        return NULL;
+    }
+
+    // now convert ARGB32 pixels to 4-bit grayscale
+    // each component of the ARGB32 values is the same
+    char *p = buf;
+    for (int j = y; j < y + *h; j++) {
+        for (int i = x; i < x + *w; i++) {
+            // get the i-th column in the j-th row of the screen buffer
+            // only keep the lowest 4 bits to get a 0-15 brightness value
+            // put this in the current cell in the output buffer
+            *p = data[j * 128 + i] & 0xF;
+            // advance the pointer into the output buffer
+            p++;
+        }
+    }
+    return buf;
+}
+```
+
+we should now be able to recompile and restart `matron`, and test
+out the new norns function in a lua repl:
+
+```lua
+>> s = screen.peek(0, 10, 128, 1)
+<ok>
+>> string.byte(s, 1)
+15
+```
+

--- a/norns/index.md
+++ b/norns/index.md
@@ -21,7 +21,7 @@ current version: [201029](https://l.llllllll.co/norns) (Oct 29 2020)
 
 ### contributing
 
-norns is the result of generous contributions by many people, and the ecosystem continues to evolve. We welcome discussion and code to help further the goal of an open, dynamic instrument creation platform. Check out the [github repo](https://github.com/monome/norns).
+norns is the result of generous contributions by many people, and the ecosystem continues to evolve. We welcome discussion and code to help further the goal of an open, dynamic instrument creation platform. Check out the [github repo](https://github.com/monome/norns). To try out the latest changes to the code, you can read about [compiling norns](/norns/compiling). There's also a guide on [extending norns](/norns/extending) if you have new functionality you'd like to add.
 
 We're also always looking for help with [documentation](https://github.com/monome/docs), if your skills include design, instruction, or proofreading. Collective efforts have created numerous exceptional projects over the years, and there's more to a project than just code!
 


### PR DESCRIPTION
Adds new doc pages `/norns/compiling` and `/norns/extending` on how to rebuild and modify the norns stack. Some users in the study group have expressed an interest in this and others might like to stay on the bleeding edge of development.

I'll follow up soon with a norns PR adding the described `screen.peek` (and `screen.poke`) functions.