### PR TITLE
fix relative links to/from compiling/extending

### DIFF
--- a/grid/index.md
+++ b/grid/index.md
@@ -40,3 +40,9 @@ However you choose to approach it, grid is lasting -- both in construction and i
 - [disassembly](disassembly) - guides for disassembling the hardware
 - [care](care) - some suggestions for device maintenance
 - [bus power upgrade](buspowerupgrade) - some early grid models had external power, they can be updated
+
+## grids in education
+
+We offer an educational discount to currently enrolled college and university students. The discount is 10%, limited to a single grid which we sell directly. contact `help@monome.org` with school and government IDs attached.
+
+In addition, we also offer institutional package pricing and workshops extending from the Grid Studies series of tutorials. Please contact `help@monome.org` for further details and to discuss how we can best introduce the grids to your students.

--- a/norns/compiling.md
+++ b/norns/compiling.md
@@ -13,7 +13,7 @@ by building the latest changes made to the code between official
 releases, either to try new features or get bug fixes as soon as
 possible. or you might want to make your own modifications to the
 software or try patches made by community members (for more details,
-see the [extending norns](/norns/extending) page).
+see the [extending norns](../norns/extending) page).
 
 norns (the sound computer) comes with everything you need to edit and
 recompile norns (the software suite). this page gives a quick guide on
@@ -49,7 +49,7 @@ output from the `ls` program.
 
 ## get up to date
 
-open a terminal and connect to norns via [SSH](/norns/play/#ssh). then
+open a terminal and connect to norns via [SSH](../norns/play/#ssh). then
 go to the `norns` directory using `cd norns`.
 
 ```bash
@@ -149,4 +149,4 @@ norns and are ready to restart. the easiest way to do that is just to
 put norns to SLEEP as usual.
 
 to continue from here and learn how to make your own changes to the
-norns code, see [extending norns](/norns/extending).
+norns code, see [extending norns](../norns/extending).

--- a/norns/extending.md
+++ b/norns/extending.md
@@ -19,7 +19,7 @@ code base, please send a [pull request on
 github](https://github.com/monome/norns/pulls)!
 
 this tutorial assumes you've already figured out how to [compile
-norns](/norns/compiling), and also assumes some familiarity with the C
+norns](../norns/compiling), and also assumes some familiarity with the C
 programming language.
 
 ## where are we going with this?

--- a/norns/index.md
+++ b/norns/index.md
@@ -21,7 +21,7 @@ current version: [201029](https://l.llllllll.co/norns) (Oct 29 2020)
 
 ### contributing
 
-norns is the result of generous contributions by many people, and the ecosystem continues to evolve. We welcome discussion and code to help further the goal of an open, dynamic instrument creation platform. Check out the [github repo](https://github.com/monome/norns). To try out the latest changes to the code, you can read about [compiling norns](/norns/compiling). There's also a guide on [extending norns](/norns/extending) if you have new functionality you'd like to add.
+norns is the result of generous contributions by many people, and the ecosystem continues to evolve. We welcome discussion and code to help further the goal of an open, dynamic instrument creation platform. Check out the [github repo](https://github.com/monome/norns). To try out the latest changes to the code, you can read about [compiling norns](../norns/compiling). There's also a guide on [extending norns](../norns/extending) if you have new functionality you'd like to add.
 
 We're also always looking for help with [documentation](https://github.com/monome/docs), if your skills include design, instruction, or proofreading. Collective efforts have created numerous exceptional projects over the years, and there's more to a project than just code!
 


### PR DESCRIPTION
Had some broken links in https://github.com/monome/docs/pull/274