### PR TITLE
install fails without libasound2-dev

### DIFF
--- a/grid/studies/nodejs/index.md
+++ b/grid/studies/nodejs/index.md
@@ -53,6 +53,8 @@ Now install the `easymidi` library:
 ```
 $ npm install --save easymidi
 ```
+Note: If you're experiencing errors while installing easymidi with npm, you might need the libasound2-dev package installed on your system. For debian: ```$ sudo apt install libasound2-dev```
+
 
 You can now copy the examples to this folder and run them using the `node` command:
 


### PR DESCRIPTION
I got a massive error log attempting to install easymidi without libasound2-dev installed. It took me quite a while to figure out the source of the problem, so I'm proposing adding a short note beneath the install instructions for easymidi.