### PR TITLE
add docs for fileselect and textentry

### DIFF
--- a/norns/reference/lib/fileselect.md
+++ b/norns/reference/lib/fileselect.md
@@ -1,0 +1,74 @@
+---
+layout: default
+nav_exclude: true
+permalink: /norns/reference/lib/fileselect
+---
+
+## fileselect
+
+### function
+
+| Syntax                    | Description                                                                                                                                                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fs.enter(folder,callback) | Invokes `fileselect` with the stated arguments. `folder` is the folder which will be first displayed in `fileselect`. `callback` requires a function which will take the resulting path from `fileselect` : function |
+
+### example
+
+```lua
+fileselect = require('fileselect')
+
+selected_file = 'none'
+selected_file_path = 'none'
+
+function callback(file_path) -- this defines the callback function that is used in fileselect
+  if file_path ~= 'cancel' then -- if a file is selected in fileselect
+    -- the following are some common string functions to help organize the path that is returned from fileselect
+    local split_at = string.match(file_path, "^.*()/")
+    selected_file_path = string.sub(file_path, 9, split_at)
+    selected_file_path = util.trim_string_to_width(selected_file_path, 128)
+    selected_file = string.sub(file_path, split_at + 1)
+    print(selected_file_path)
+    print(selected_file)
+  end
+redraw()
+end
+
+function redraw()
+  screen.clear()
+  screen.level(15)
+  screen.move(0,10)
+  screen.text('selected file path:')
+  screen.move(0,20)
+  screen.text(selected_file_path)
+  screen.move(0,30)
+  screen.text('selected file:')
+  screen.move(0,40)
+  screen.text(selected_file)
+  screen.move(0,60)
+  screen.text('press K3 to select file')
+  screen.update()
+end
+
+function key(n,z)
+  if n == 3 and z == 1 then
+    fileselect.enter(_path.audio,callback) -- runs fileselect.enter; `_path.audio` in this example is the folder that will open when fileselect is run
+  end
+end
+```
+
+### description
+
+`fileselect` provides a way to navigate directories from a given folder and to select a file from within that folder and any sub-folders. It returns the absolute path of the selected file. If no file is selected, then it returns `cancel`.
+
+Note that `fileselect` provides its own handlers for screen redraw, encoders, and keys. `fileselect` automatically redraws the screen when its `.enter` function is invoked. K3 becomes ENTER, K2 becomes BACK. If K2 is pressed when on the top-level of the specified filepath, `fileselect` will exit and return to your script's UI with its own redraw.
+
+In the example's `key` function, we use `_path.audio` as shorthand for `/home/we/dust/audio/`. Here are the other paths aliased within the `_path` table:
+
+```
+dust    /home/we/dust/
+tape    /home/we/dust/audio/tape/
+home    /home/we
+code    /home/we/dust/code/
+data    /home/we/dust/data/
+audio    /home/we/dust/audio/
+```

--- a/norns/reference/lib/textentry.md
+++ b/norns/reference/lib/textentry.md
@@ -1,0 +1,73 @@
+---
+layout: default
+nav_exclude: true
+permalink: /norns/reference/lib/textentry
+---
+
+## textentry
+
+### functions
+
+| Syntax                                             | Description                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| textentry.enter(callback, default, heading, check) | Invokes `textentry` with the stated arguments. `callback` requires a function which receives the result of `textentry`. `default` is an optional default text presented to the user. `heading` is an optional header in the UI. `check` is an optional function which can check the entered text and display a warning or success : function |
+
+### example
+
+```lua
+textentry = require('textentry')
+
+my_string_1 = "replace me by pressing K3"
+my_string_2 = "replace me in params"
+
+function init()
+  params:add_trigger('change_string_2', 'change string 2 here')
+  params:set_action('change_string_2', function() textentry.enter(callback_2,my_string_2) end)
+end
+
+function callback_1(txt)
+  if txt ~= nil and check(txt) ~= "too long" then
+    my_string_1 = txt
+  end
+  redraw()
+end
+
+function callback_2(txt)
+  if txt ~= nil then
+    my_string_2 = txt
+  end
+  redraw()
+end
+
+function check(txt)
+  if string.len(txt) > 10 then
+    return "too long"
+  else
+    return ("remaining: "..10 - string.len(txt))
+  end
+end
+
+function redraw()
+  screen.clear()
+  screen.move(0,30)
+  screen.text(my_string_1)
+  screen.move(0,40)
+  screen.text(my_string_2)
+  screen.update()
+end
+
+function key(n,z)
+  if n == 3 and z == 1 then
+    local default_text = my_string_1 ~= "replace me by pressing K3" and my_string_1 or ""
+    textentry.enter(callback_1,default_text,"enter 10 chars or less", check)
+  end
+end
+```
+
+### description
+
+`textentry` provides a handy utility for text input, either in your on-screen UI (`my_string_1` in the example) and within the parameters system (`my_string_2`). It's a helpful way to integrate text input into your script's interactions and has the advantage of familiarity since it's used in system-level screens like `TAPE` and `WIFI`.
+
+Note that `textentry` provides its own handlers for screen redraw, encoders, and keys. `textentry` automatically redraws the screen when its `.enter` function is invoked. K3 becomes ENTER, K2 becomes EXIT. E3 switches between rows and E2 scrolls within each row.
+
+`textentry` returns a string according to the input, which is then fed into the script-defined callback function. If the user exits the `textentry` ui without pressing `OK` then `textentry` returns `nil`, so it's a good practice to weed out the `nil` in your callback function.


### PR DESCRIPTION
New addition of documentation for the norns reference, for two libraries: lib/fileselect and lib/textentry. Currently, there is no documentation for these two libraries. This was done together with @dndrks