### PR TITLE
fixed broken links in ui.md

### DIFF
--- a/norns/reference/lib/ui.md
+++ b/norns/reference/lib/ui.md
@@ -29,14 +29,14 @@ Contributed by @markeats.
 
 | Feature                          | Description               |
 | -------------------------------- | ------------------------- |
-| [dial](./dial)                   | Dial UI element           |
-| [list](./list)                   | List UI element           |
-| [message](./message)             | Message UI element        |
-| [pages](./pages)                 | Pages UI element          |
-| [scrollinglist](./scrollinglist) | Scrolling list UI element |
-| [slider](./slider)               | Slider UI element         |
-| [tabs](./tabs)                   | Tabs UI element           |
-| [playback icon](./playbackicon)  | Playback icon UI element  |
+| [dial](./ui/dial)                   | Dial UI element           |
+| [list](./ui/list)                   | List UI element           |
+| [message](./ui/message)             | Message UI element        |
+| [pages](./ui/pages)                 | Pages UI element          |
+| [scrollinglist](./ui/scrollinglist) | Scrolling list UI element |
+| [slider](./ui/slider)               | Slider UI element         |
+| [tabs](./ui/tabs)                   | Tabs UI element           |
+| [playback icon](./ui/playbackicon)  | Playback icon UI element  |
 
 ### example
 


### PR DESCRIPTION
https://monome.org/docs/norns/reference/lib/ui currently has broken links to the individual element doc pages. Not sure exactly why that's the case since it works when I locally build the site. Since it works either way on my local build, I'm not entirely sure if this fix will work, but I think making the folder structure clear might do the trick. Sorry for the trouble!