### PR TITLE
Add multiline druid send mapping for vim

### DIFF
--- a/crow/druid.md
+++ b/crow/druid.md
@@ -165,6 +165,12 @@ In `vim` here's how to bind the keystroke `CTRL-\` which executes the current li
 map <C-\> :silent .w !websocat ws://localhost:6666 -1<CR>
 ```
 
-Copy the line above to your `.vimrc` to make it permanent. This command requires [websocat](https://github.com/vi/websocat).
+And here's how to bind the keystroke `F5` to execute all highlighted lines:
+
+```
+vmap <F5> :w<Home>silent <End> !websocat ws://localhost:6666<CR>
+```
+
+Copy either or both of the lines above to your `.vimrc` to make it permanent. This command requires [websocat](https://github.com/vi/websocat).
 
 Other scriptable editors should be able to send data to a websocket--- we'll collect examples here as they are created.

--- a/crow/druid.md
+++ b/crow/druid.md
@@ -165,10 +165,10 @@ In `vim` here's how to bind the keystroke `CTRL-\` which executes the current li
 map <C-\> :silent .w !websocat ws://localhost:6666 -1<CR>
 ```
 
-And here's how to bind the keystroke `F5` to execute all highlighted lines:
+And here's how to bind the keystroke `F5` to execute all highlighted lines as one block, enabling e.g. function definitions:
 
 ```
-vmap <F5> :w<Home>silent <End> !websocat ws://localhost:6666<CR>
+vmap <F5> :w<Home>silent <End> !sed -e '1i\```' -e '$a\```' <bar> websocat ws://localhost:6666<CR>
 ```
 
 Copy either or both of the lines above to your `.vimrc` to make it permanent. This command requires [websocat](https://github.com/vi/websocat).


### PR DESCRIPTION
As requested by @tehn in the norns study group discord.

Tested with Vim 8.2 / Druid 1.1.1 (installed from pip).