### PR TITLE
EXAMPLE: fix typo in maps s2e2 example

### DIFF
--- a/crow/maps/s2e2.md
+++ b/crow/maps/s2e2.md
@@ -264,6 +264,7 @@ function big_melody2()
       clock.sleep(stage[2]) -- the second entry describes time
     end
   end
+  )
 end
 
 ```


### PR DESCRIPTION
this code seems to be missing a parenthesis. There should be a parenthesis to close the clock.run(function().