### PR TITLE
Fix markdown syntax so title renders correctly

### DIFF
--- a/switch/index.md
+++ b/switch/index.md
@@ -24,7 +24,7 @@ Attach the included 9v power adapter to the input plug labeled '9-24V DC' at the
 Output power consumption to your USB device is limited to 1A to protect against short circuits.
 
 
-##Power
+## Power
 
 Switch adds an additional 5v power supply to a Eurorack modular system specifically to power a monome grid, though any USB-compliant controller can be powered also.
 


### PR DESCRIPTION
Hi! I found what appears to be a minor syntax issue [preventing the 'power' title rendering on the Switch docs](https://monome.org/docs/switch/). Hope this is helpful, please feel free to close without comment if not.

<img width="739" alt="Screen Shot 2021-09-10 at 7 12 44 pm" src="https://user-images.githubusercontent.com/495961/132830609-c20e6cbd-0737-4bc2-972b-94b9e487e13e.png">
