### PR TITLE
Added redraw() call on line 762 and 796

### DIFF
--- a/norns/study-3.md
+++ b/norns/study-3.md
@@ -759,6 +759,7 @@ end
 function enc(n,d)
   if n == 3 then
     params:delta("cutoff",d)
+    redraw()
   end
 end
 ```
@@ -792,6 +793,7 @@ end
 function enc(n,d)
   if n == 3 then
     params:delta("cutoff",d)
+    redraw()
   end
 end
 


### PR DESCRIPTION
Under the "more control + sound" section of Study 3, the student assigns Encoder 3 to delta the cutoff parameter while displaying the parameter on the Norns display, but the number on the display doesn't change when the parameter is changed since redraw() is never called in function enc(). 

Adding a redraw() call inside the enc(n,d) function solves this.