### PR TITLE
Fixing a small typo

### DIFF
--- a/crow/norns.md
+++ b/crow/norns.md
@@ -43,7 +43,7 @@ Crow's voltage range is -5.0 to 10.0 for outputs 1 to 4.
 
 Run `2-input.lua`.
 
-- Connect an LFO output to crow input 1. K1 will capture the current value. K2 will toggle `stream` mode on and off.
+- Connect an LFO output to crow input 1. K2 will capture the current value. K3 will toggle `stream` mode on and off.
 - Connect the same cable to input 2 which is set up to trigger a `change` function on each transition.
 
 Inputs have several modes:


### PR DESCRIPTION
Under the input section, references to keys 1 and 2 should actually be references to keys 2 and 3.

See the code in lines 49 and 51 here: https://github.com/monome/crow-studies/blob/master/2-input.lua