### PR TITLE
fix typo in crow maps code example

### DIFF
--- a/crow/maps/s2e1.md
+++ b/crow/maps/s2e1.md
@@ -74,7 +74,7 @@ clock.tempo = clock.tempo/2
 [at this point in the video](https://youtu.be/WQyoDRRQ5Qg?t=1919), Trent uses a special protocol and command to communicate to another module's (w/) digital synthesis mode:
 
 ```lua
-clock.run(function() while true do clock.sync(1); ii.wysn.play_note(0,0.9) end end)
+clock.run(function() while true do clock.sync(1); ii.wsyn.play_note(0,0.9) end end)
 ```
 
 if you don't have access to this module, here's a version of the code he's written which will send v/8 CV to crow output 1 and a trigger pulse to crow output 2:
@@ -151,7 +151,7 @@ clock.run(
   function()
     while true do
       clock.sync(1)
-      ii.wysn.play_note(mys()/12,0.9)
+      ii.wsyn.play_note(mys()/12,0.9)
     end
   end
 )
@@ -160,7 +160,7 @@ clock.run(
 one-line w/syn code:
 
 ```lua
-mys = sequins{0,2,4,7,9}; clock.run(function() while true do clock.sync(1); ii.wysn.play_note(mys()/12,0.9) end end)
+mys = sequins{0,2,4,7,9}; clock.run(function() while true do clock.sync(1); ii.wsyn.play_note(mys()/12,0.9) end end)
 ```
 
 if you don't have access to this module, here's a version of the code he's written which will send v/8 CV to crow output 1 and a trigger pulse to crow output 2.
@@ -247,7 +247,7 @@ clock.run(
   function()
     while true do
       clock.sync(myt())
-      ii.wysn.play_note(mys()/12,0.9)
+      ii.wsyn.play_note(mys()/12,0.9)
     end
   end
 )
@@ -256,7 +256,7 @@ clock.run(
 one-line w/syn code:
 
 ```lua
-mys = sequins{0,2,4,7,9}; myt = sequins{1,1,1,1/2,1/2}; clock.run(function() while true do clock.sync(myt()); ii.wysn.play_note(mys()/12,0.9) end end)
+mys = sequins{0,2,4,7,9}; myt = sequins{1,1,1,1/2,1/2}; clock.run(function() while true do clock.sync(myt()); ii.wsyn.play_note(mys()/12,0.9) end end)
 ```
 
 if you don't have access to this module, here's a version of the code he's written which will send v/8 CV to crow output 1 and a trigger pulse to crow output 2.


### PR DESCRIPTION
a small typo in the code sample using w/syn - `ii.wysn` -> `ii.wsyn`