### PR TITLE
crow release touchups

### DIFF
--- a/crow/druid.md
+++ b/crow/druid.md
@@ -8,19 +8,29 @@ has_children: no
 ---
 
 # druid
+{: .no_toc }
 
 ![](../images/druid-start.png)
 
-To communicate with crow we'll use `druid`, a command-line tool that lets you send & receive text, as well as run & upload scripts.
+To communicate with crow we'll use `druid`, a command-line tool that lets you send and receive text, as well as run and upload scripts.
+
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
 
 ## preparation
 
-First we'll collect & install a few tools, starting with `Python` which is the environment that runs `druid`. Don't worry, you don't ever have to type any Python code into `druid`.
+First we'll collect and install a few tools, starting with `Python` which is the environment that runs `druid`. Don't worry, you don't ever have to type any Python code into `druid`.
 
-`druid` requires Python 3.6+, but let's get the most recent version (3.8 as of this writing, November 2019):
+`druid` requires Python 3.6+, but let's get the most recent version (3.11 as of this writing, March 2023):
 
 - macOS: [download from the Python website](https://www.python.org/downloads/)
-- Windows: search `Python 3.8` in the Microsoft Store (it's free)
+- Windows: search `Python 3.11` in the Microsoft Store (it's free)
 	- the Microsoft Store is the most straightforward way to install Python on Windows, but if you choose to install from the Python website directly then please follow [these instructions](https://docs.google.com/document/d/11Bnly-JOBh4_mWSyIGmEIpE_YO-6VH179KSHEWTZr2M/edit)
 - Linux: in a terminal run `sudo apt-get install python3 python3-pip` or equivalent
 
@@ -36,9 +46,7 @@ Check if Python is installed and working:
 python3 -V
 ```
 
-Which should print `Python 3.8` or something similar. If this doesn't work for you, try removing the `3` and just run `python -V`.
-
-No luck? Post to the [lines thread](https://llllllll.co/t/crow-help-druid/25864) & we'll figure it out (and update this doc).
+Which should print `Python 3.11` or something similar. If this doesn't work for you, try removing the `3` and just run `python -V`.
 
 Now it's time to install `druid`!
 
@@ -59,7 +67,7 @@ NB: If you see an error like "ERROR: Could not install packages due to an Enviro
 sudo pip3 install monome-druid
 ```
 
-*Close & reopen your terminal*, then run `druid` to start scripting.
+*Close and reopen your terminal*, then run `druid` to start scripting.
 
 ### update
 
@@ -127,9 +135,9 @@ You should see druid open with the following message up top:
 <crow connected>
 ```
 
-If you see `<crow disconnected>` instead, make sure your modular case with crow is turned on, and the USB cable is connected. If everything is connected but still not connecting, close your Terminal application & restart it.
+If you see `<crow disconnected>` instead, make sure your modular case with crow is turned on, and the USB cable is connected. If everything is connected but still not connecting, close your Terminal application and restart it.
 
-If `druid` responds with `can't open serial port` you probably don't have the required permissions to open the device.
+If `druid` responds with `can't open serial port` you probably don't have the required permissions to open the device. See below.
 
 ### Permissions
 
@@ -159,6 +167,8 @@ It's possible to send lines of text to druid (which are forwarded to crow) using
 
 This allows you to execute crow commands from outside of druid, for example within your text editor.
 
+Though other scriptable editors should be able to send data to a websocket, we'll explore `vim` as an example.
+
 In `vim` here's how to bind the keystroke `CTRL-\` which executes the current line:
 
 ```
@@ -172,5 +182,3 @@ vmap <F5> :w<Home>silent <End> !sed -e '1i\```' -e '$a\```' <bar> websocat ws://
 ```
 
 Copy either or both of the lines above to your `.vimrc` to make it permanent. This command requires [websocat](https://github.com/vi/websocat).
-
-Other scriptable editors should be able to send data to a websocket--- we'll collect examples here as they are created.

--- a/crow/faq.md
+++ b/crow/faq.md
@@ -7,17 +7,22 @@ permalink: /crow/faq/
 ---
 
 # crow questions
+{: .no_toc }
 
-- [dictionary](#dictionary)
-- [scripting](#scripting)
-- [hardware](#hardware)
-- [i2c](#i2c-head)
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
 
-## dictionary of crow terms<a name="dictionary"></a>
+## dictionary of crow terms {#dictionary}
 
 ### i2c
 
-i2c is a communication bus - it’s a way for devices to talk to each other, similar to MIDI or USB. In the monome ecosystem, an i2c protocol called "ii" provides a convenient way to send commands & data between modules. In some situations reducing what could be many patch-cable connections down to a single i2c cable hidden behind the module. For example, crow can send unique synthesis commands to [Just Friends](https://www.whimsicalraps.com/products/just-friends), accessible only with the ii protocol.
+[i2c](/docs/modular/ii) is a communication bus - it’s a way for devices to talk to each other, similar to MIDI or USB. In the monome ecosystem, an i2c protocol called "ii" provides a convenient way to send commands & data between modules. In some situations reducing what could be many patch-cable connections down to a single i2c cable hidden behind the module. For example, crow can send unique synthesis commands to [Just Friends](https://www.whimsicalraps.com/products/just-friends), accessible only with the ii protocol.
 
 ### druid
 
@@ -61,7 +66,7 @@ Using the scripting reference, you could:
 - write a norns script that tells crow to wait for triggers at its inputs to create different types of envelopes
 - you can upload a full script to crow so that it knows what it’s meant to do when it's not connected to a computer or norns, and it would just await external triggers or control voltage at its inputs
 
-## scripting<a name="scripting"></a>
+## scripting
 
 ### how large a script can I run or store on crow in standalone?
 
@@ -104,7 +109,7 @@ The `[sprintf]` object is the easiest way to format messages to crow. Using the 
 - we send the string to `[prepend tell_crow]` to format the instruction
 - and finally, we send that formatted message to `[crow]`!
 
-## hardware<a name="hardware"></a>
+## hardware
 
 ### one of crow's inputs doesn't seem to respond to triggers
 

--- a/crow/first.md
+++ b/crow/first.md
@@ -20,7 +20,7 @@ Example patch:
 - Output 1+2 -> Mangrove v8 & air
 - Output 3+4 -> VCO frequency & VCA level
 
-Start the sequence by patching a clock or LFO into input 1. Each time the voltage rises above 1V *First* will take a step forward. As the patch comes alive, slow the clock down to hear long gentle swells, then ramp it up into snappy arpeggios.
+Start the sequence by patching a clock or LFO into input 1. Each time the voltage rises above 1V, *First* will take a step forward. As the patch comes alive, slow the clock down to hear long gentle swells, then ramp it up into snappy arpeggios.
 
 To influence the melodic content, attach a control voltage to input 2. As voltages rise up from 0V, the melodies will spread out to take up more harmonic space. Positive voltages play a pentatonic scale, while below 0V two notes are added to enter the ionian mode, similarly widening the melody toward -5V.
 

--- a/crow/index.md
+++ b/crow/index.md
@@ -36,7 +36,7 @@ If you would like to use the [ii](/docs/modular/ii) functionality, be sure to ob
 
 ### norns
 
-crow integrates seamlessly with norns as a CV and [ii](/docs/modular/ii) interface. By default, crow can be a norns clocking source or destination. [Many scripts have additional crow functionality](https://llllllll.co/search?expanded=true&q=tags%3Acrow%2Bnorns%20order%3Alatest).
+crow integrates seamlessly with norns as a CV and [ii](/docs/modular/ii) interface. By default, crow can be a norns clocking source or destination. [Many scripts have additional crow functionality](https://norns.community/t/crow).
 
 Want to script on your own? See the full [crow studies](norns) for a complete guide
 
@@ -63,10 +63,11 @@ Afterward, visit the [Max and Max for Live repo on GitHub](https://github.com/mo
 
 If you are writing or modifying norns scripts, standalone druid snippets, or Max patches, you'll want to visit the [scripting reference](reference) to become fluent in the language of the birds.
 
-## Updates + Development
+## Updates
 
-We are working all the time. Check out the [newest firmware version](https://github.com/monome/crow/releases/latest).  
-To update, visit the step-by-step [bootloader instructions](update).
+To update crow, review [the step-by-step instructions](update).
+
+## Development
 
 crow continues to evolve and you can follow development on GitHub: [https://github.com/monome/crow](https://github.com/monome/crow)  
 crow is open-source and is built on the efforts of other open-source projects. Contributions are welcome.

--- a/crow/index.md
+++ b/crow/index.md
@@ -18,7 +18,6 @@ crow also stores a complete script, so that without a USB connection it can cont
 
 A collaboration by [Whimsical Raps](https://www.whimsicalraps.com) and monome.
 
-
 ## Specifications
 
 - Eurorack, 2hp width, 41mm depth
@@ -26,7 +25,6 @@ A collaboration by [Whimsical Raps](https://www.whimsicalraps.com) and monome.
 - 2 input, 4 output, 16bit [-5V,10V] range
 - Rear panel digital communication bus via [ii/i2c](/docs/ansible/i2c/#what-is-i2c--ii) (cables available [here](https://www.adafruit.com/product/266))
 - full Lua scripting environment
-
 
 ## Installation
 
@@ -38,13 +36,13 @@ If you would like to use the [ii](/docs/modular/ii) functionality, be sure to ob
 
 ### norns
 
-On October 1st 2019, we released a norns [update](../norns/#update) which allows crow to integrate seamlessly as a CV and [ii](/docs/modular/ii) interface. [Many scripts have already been updated to utilize crow](https://llllllll.co/search?expanded=true&q=tags%3Acrow%2Bnorns%20order%3Alatest).
+crow integrates seamlessly with norns as a CV and [ii](/docs/modular/ii) interface. By default, crow can be a norns clocking source or destination. [Many scripts have additional crow functionality](https://llllllll.co/search?expanded=true&q=tags%3Acrow%2Bnorns%20order%3Alatest).
 
 Want to script on your own? See the full [crow studies](norns) for a complete guide
 
 ### computer + druid
 
-You can use your terminal to access [druid](druid), a small utility for communicating with crow. druid helps you engage crow in realtime interaction and also upload full scripts (coded in Lua), providing an interactive platform for designing new patterns in a modular synth.
+You can use your computer's terminal to access [druid](druid), a small utility for communicating with crow. druid helps you engage crow in realtime interaction and also upload full scripts (coded in Lua), providing an interactive platform for designing new patterns in a modular synth.
 
 Want to see what others have scripted? Visit [bowery](https://github.com/monome/bowery), the druid script collection, and complete *stage one* of the [scripting tutorial](scripting) to learn how to upload scripts.
 
@@ -58,37 +56,23 @@ Using the custom `[crow]` object in Max 8, create your own Live-controllable dev
 
 We have also created Max for Live devices to integrate crow with Ableton Live, including: synced clocks, MIDI-to-v/8, CC-to-voltage (which can be mapped to any software modulation source), i2c communication with [Just Friends](https://www.whimsicalraps.com/products/just-friends?variant=5586981781533), executing Lua code directly in Live, parameter mapping your crow scripts, and triggering Lua chunks with MIDI.
 
-Want to learn more? [Check out the docs.](/docs/crow/max-m4l/)  
+Want to learn more? [Check out the docs](/docs/crow/max-m4l/).  
 Afterward, visit the [Max and Max for Live repo on GitHub](https://github.com/monome/crow-max) to get started.
 
 ### scripting reference
 
-If you are writing or modifying norns apps, standalone scripts, or Max patches, you will want to become fluent in the language of the birds. Visit the [scripting reference](reference) to become a crow whisperer
+If you are writing or modifying norns scripts, standalone druid snippets, or Max patches, you'll want to visit the [scripting reference](reference) to become fluent in the language of the birds.
 
-## Updates
+## Updates + Development
 
-We are working all the time. Check out the [newest firmware version](https://github.com/monome/crow/releases/latest).
+We are working all the time. Check out the [newest firmware version](https://github.com/monome/crow/releases/latest).  
+To update, visit the step-by-step [bootloader instructions](update).
 
-To update, visit the step by step [bootloader instructions](update).
+crow continues to evolve and you can follow development on GitHub: [https://github.com/monome/crow](https://github.com/monome/crow)  
+crow is open-source and is built on the efforts of other open-source projects. Contributions are welcome.
 
-## Help
+## Further
 
-Answers to frequently asked questions can be found in [crow questions](faq).
-
-Community discussion happens at [llllllll.co](https://llllllll.co). Come say hello!
-
-Contact *help@monome.org* with further questions.
-
-## Calibration
-
-There are also a subset of commands for managing the state of the device and contents of flash memory. crow ships pre-calibrated, but it is possible to re-run the automatic calibration.
-See the [technical](technical) page for further details.
-
-
-## Development
-
-crow continues to evolve and you can follow development on github:
-
-[https://github.com/monome/crow](https://github.com/monome/crow)
-
-crow is open-source and is built on the efforts of other open source projects. Contributions are welcome.
+Answers to frequently asked questions can be found in [crow questions](faq).  
+Community discussion happens at [llllllll.co](https://llllllll.co). Come say hello!  
+Contact *help@monome.org* for direct support.

--- a/crow/manual-update.md
+++ b/crow/manual-update.md
@@ -10,6 +10,15 @@ permalink: /crow/manual-update/
 
 Flashing the crow requires setting up `dfu-util` on your laptop, downloading the new firmware, and getting crow connected in bootloader mode.
 
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
 ## Setup dfu-util<a name="setup"></a>
 
 - Linux: `apt-get install dfu-util` (or similar)

--- a/crow/max-m4l.md
+++ b/crow/max-m4l.md
@@ -10,7 +10,6 @@ permalink: /crow/max-m4l/
 
 # Max and Max for Live
 
-
 [Max](https://cycling74.com) is a powerful visual coding language that has integrations with [Ableton Live](https://www.ableton.com/en/live/max-for-live/).
 
 We have created a custom `[crow]` object and several helpful abstractions for Max, to welcome crow into your existing and future patches.
@@ -29,7 +28,7 @@ After downloading the entire `crow-max-and-m4l` repo, extract the zip file and y
 
 Open `Max` > `Options` > `File Preferences` > highlight `User Library` > the rightmost icon in the bottom bar should illuminate. Clicking this icon will open the User Library folder, where you can drop the `crow_max` folder.
 
-If you are performing an update of an existing `crow_max` installation, you can simply allow the system to replace the existing files. If you somehow have previous **beta** crow files in your User Library (or anywhere along your Max search path), please delete them and start fresh with `crow_max`.
+If you are performing an update of an existing `crow_max` installation, you can simply allow the system to replace the existing files. If you have previous crow files in your User Library (or anywhere along your Max search path), please delete them and start fresh with `crow_max`.
 
 Restart Max and you should be able to instantiate the `crow` object!
 
@@ -57,23 +56,14 @@ In addition to the `crow` object, there are many helper objects which can aid in
 - `crow.adsr`: easily configure and trigger an ADSR envelope on one of crow's outputs
 - `crow.var`: assign a value, table, variable, or function return to a variable (or to an element of a table)
 - `crow.function`: tell crow to execute a function, or generate a function call to pass to another `crow.` object.
-- `crow.makefunction`: convert a value, variable, or function call into an anonymous function that returns the original value/variable/function call.
+- `crow.dyn`: quickly format a dynamic variable.
 - `crow.n2v`: convert semitones to V/oct voltage levels.
-
-### ^^bootloader
-To help make flashing [new crow firmware](https://github.com/monome/crow/releases) easy, we've included a straightforward Max patch that walks through the necessary steps:
-
-![](../images/max-bootloader.png)
-
-You can either open it from inside the `crow_max` folder **or** by opening a new patcher in Max and instantiating a `^^bootloader` object (lock the patch and double-click the object to open the bootloader helper).
-
-After loading new firmware, you will need to re-establish the connection between Max and the crow module but there is no need to reboot your modular.
 
 ## Max for Live
 
 ### Install
 
-*nb. Max installation is **not** required to use the devices in `crow_m4l`.*
+*Max installation is **not** required to use the devices in `crow_m4l`.*
 
 After downloading the entire `crow-max-and-m4l` repo, extract the zip file and you should get two unique folders: `crow_max` and `crow_m4l`.
 

--- a/crow/norns.md
+++ b/crow/norns.md
@@ -11,17 +11,25 @@ permalink: /crow/norns/
 
 ![](../images/crow-norns.png)
 
-# Rising: Crow Studies
+# Rising: crow Studies
 
-Crow serves as a CV and ii interface for norns.
+crow serves as a CV and [ii](/docs/modular/ii) interface for norns.
 
-It may be helpful to first explore the [norns studies](../../norns/study-1) to provide context for how to integrate crow's new functionality.
+Before venturing further, it may be helpful to first explore the [norns studies](/docs/norns/studies) to provide context for how to integrate crow's functionality.
 
 Download: [github.com/monome/crow-studies](https://github.com/monome/crow-studies)
 
-(Note: be sure your norns is [updated](../../norns/#update) to version 191016 or later.)
+crow will automatically be detected and interfaced upon connection to norns.  
+Presently, only a single crow is supported.
 
-Crow will automatically be detected and interfaced upon connection to norns. Presently only a single crow is supported.
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
 
 ## 1. Output
 
@@ -117,18 +125,6 @@ Run `3-ii.lua`.
 
 Attach a Just Friends via [ii](/docs/modular/ii). Be sure to align the GND pins. K2 will play an ascending note, K3 plays a random note.
 
-The ii bus requires pullup resistance, which can be toggled by crow:
-
-```lua
-crow.ii.pullup(true)
-```
-
-If your ii bus is already pulled up (by Teletype or a powered bus board, for example), you can erase this line (as pullup is off by default), or explicitly turn off pullups like this:
-
-```lua
-crow.ii.pullup(false)
-```
-
 To change JF's mode and play a note:
 
 ```lua
@@ -215,7 +211,7 @@ Each time `query` is called, crow will send a value to the function `receive`. T
 
 Run `5-construct.lua`. Crow outputs 1-4 are 5-segment looping envelopes, each with its own unique shape and trajectory. E1 will change the timebase from which these LFOs are constructed. K2 will construct new LFOs at the specified timebase. K3 will restart the LFOs from 0V. The current Voltage output is displayed as meters on the left.
 
-crow can speak a slope language, affectionately referenced as **a/s/l**. In the previous script, we learned how a/s/l's `to` command can be used to create multipoint envelopes using Voltage and time. `to` also has a third argument for shape, which defines *how* we move from Voltage to Voltage across time. If we do not define the shape, `to` commands default to linear movement.
+crow can speak a slope language, referred to as **ASL**. In the previous script, we learned how ASL `to` command can be used to create multipoint envelopes using Voltage and time. `to` also has a third argument for shape, which defines *how* we move from voltage to voltage across time. If we do not define the shape, `to` commands default to linear movement.
 
 *nb. This script uses some extended techniques, so don't worry if it feels a little heady.*
 

--- a/crow/scripting-druid.md
+++ b/crow/scripting-druid.md
@@ -10,6 +10,7 @@ permalink: /crow/scripting-druid/
 ---
 
 # Scripting
+{: .no_toc }
 
 Scripts are the little programs crow runs to take on different roles in your synthesizer. They are written in [Lua](https://www.lua.org) and typically run between 10 and 100 lines. You don't need to write them from scratch though! There's examples to upload directly, and modifying existing scripts is a nice soft entry into writing your own.
 
@@ -33,25 +34,34 @@ If you wish to venture on from there, *Stage Two* demonstrates:
 
 And *Stage Three* concludes with [a brief introduction into writing & modifying crow scripts](#sample-and-hold).
 
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
 ## Stage One: Upload
 
 ### Bowery
 
 Before we can upload a script, we need some scripts to upload! There's a set of examples, and a growing collection of user-provided scripts available in the *bowery* repository.
 
-Navigate to [bowery](https://github.com/monome/bowery/releases/latest) and download the .zip file under *Assets*. It will be named `bowery-X`, where X is the release number. Unzip it wherever you'd like to keep your crow scripts.
+Navigate to [bowery](https://github.com/monome/bowery/) and [download the repository as a .zip file](https://github.com/monome/bowery/archive/refs/heads/main.zip). Unzip it wherever you'd like to keep your crow scripts.
 
-Return to your terminal & quit `druid` by typing `q` then `<enter>`. Now in terminal, change-directory (or `cd`) to enter the bowery folder. If you unzip within your Documents folder it would be `cd ~/Documents/bowery-X`.
+Return to your terminal & quit `druid` by typing `q` then `<enter>`. Now in terminal, change-directory (or `cd`) to enter the bowery folder. If you unzip within your Documents folder it would be `cd ~/Documents/bowery-main`.
 
 **Having trouble using the `cd` command?**
 
-- Mac: right click the unzipped `bowery-X` folder and then press the OPTION key. This will reveal a **Copy "bowery-X" as Pathname** action. Select it and then paste into terminal after `cd [spacebar]`.
-- Windows: hold the SHIFT key and right click the unzipped `bowery-X` folder. This will reveal a **Copy as path** action. Select it and then paste into terminal after `cd [spacebar]`.
-- Linux: right click the unzipped `bowery-X` folder and select "**Copy**". Then, simply **Paste** into terminal after `cd [spacebar]`.
+- Mac: right click the unzipped `bowery-main` folder and then press the OPTION key. This will reveal a **Copy "bowery-main" as Pathname** action. Select it and then paste into terminal after `cd [spacebar]`.
+- Windows: hold the SHIFT key and right click the unzipped `bowery-main` folder. This will reveal a **Copy as path** action. Select it and then paste into terminal after `cd [spacebar]`.
+- Linux: right click the unzipped `bowery-main` folder and select "**Copy**". Then, simply **Paste** into terminal after `cd [spacebar]`.
 
 ### Uploading
 
-From the *bowery-X* folder, load up a fresh `druid` session so we can talk to crow.
+From the *bowery-main* folder, load up a fresh `druid` session so we can talk to crow.
 
 ```
 druid
@@ -72,7 +82,7 @@ You just uploaded your first crow script!
 
 Patch a trigger or LFO into input 1 and crow will now be sending clock divided gates to all 4 outputs. Try patching crow's outputs to anything expecting triggers. Make some envelopes with Just Friends' *trigger* inputs in *shape/transient* mode, or ping Three Sisters' filters by patching crow's outputs directly to Three Sisters' 4 input jacks and turn *quality* up to 3:00 on the dial.
 
-A voltage into input 2 will select between different sets of divisions as you sweep from -5V to +5v. Open `bowery-X/clockdiv.lua` in a text editor and edit the table called `divs` which represents the clock-divisions per output, with 5 different sets to choose from.
+A voltage into input 2 will select between different sets of divisions as you sweep from -5V to +5v. Open `bowery-main/clockdiv.lua` in a text editor and edit the table called `divs` which represents the clock-divisions per output, with 5 different sets to choose from.
 
 Any time you make changes to `clockdiv.lua` you'll need to run the script again with `r clockdiv.lua`. If you want your changes to stick around when you restart crow change `r` (run) to `u` (upload) like this; `u clockdiv.lua`. We recommend you use `r` most of the time as it's faster, then once you settle on something you like use `u` to save it into crow's longterm memory.
 
@@ -266,7 +276,7 @@ Copy this to the bottom of the script, and replace the comment with the `print` 
 
 ```lua
 input[1].change = function(state)
-    print('BANG!')
+    print('BOOP!')
 end
 ```
 
@@ -277,12 +287,12 @@ Patch a clock source to input 1, then save the script and run it:
  running sketch.lua
 Running: sample & hold
 ...
-BANG!
-BANG!
-BANG!
+BOOP!
+BOOP!
+BOOP!
 ```
 
-Those *BANG!*s tell us the input is correctly setup and detecting the clock signal. Now rather than having crow shout at us, let's create the elusive random voltage.
+Those *BOOP!* 's tell us the input is correctly setup and detecting the clock signal. Now rather than having crow shout at us, let's create the elusive random voltage.
 
 ```lua
 input[1].change = function(state)
@@ -345,7 +355,7 @@ This short script is already a nice sample & hold. It creates a random value and
 
 One great source of inspiration when it comes to sample & hold and other forms of randomness is the Buchla 'Source of Uncertainty' module, but for now that's up to you to explore!
 
-## The neverending story
+## The never-ending story
 
 More explorations will be here or around soon:
 

--- a/crow/seededrandom.md
+++ b/crow/seededrandom.md
@@ -3,7 +3,7 @@ layout: default
 nav_exclude: true
 ---
 
-# Seeded vs true random
+# Seeded vs True Random
 
 crow's microcontroller has a true-random-number-generator on board. This is the random source that is hooked up to the `math.random` function and should reliably produce numbers with high entropy.
 

--- a/crow/update.md
+++ b/crow/update.md
@@ -26,7 +26,7 @@ To check the current version of your crow inside of druid, type `^^version` into
 
 *Huge thanks to all the contributors!*
 
-#### NEW
+**NEW**
 
 - `timeline` library: [DOCS](https://monome.org/docs/crow/timeline/)  
 - `sequins`: transformers: [DOCS](https://monome.org/docs/crow/sequins2/#transformers)  
@@ -37,7 +37,7 @@ To check the current version of your crow inside of druid, type `^^version` into
 - extended `disting` ii interface (thanks @jroo, @ryland)  
 - method for peeking the current sequins value (thanks @tyleretters)  
 
-#### FIXED
+**FIXED**
 
 - ASL segments now correctly handle `'log'` shapes (thanks @beels)  
 - dsp samplerate was incorrect. ASL now runs at the correct speed  

--- a/crow/update.md
+++ b/crow/update.md
@@ -7,10 +7,54 @@ permalink: /crow/update/
 ---
 
 # Firmware Update
+{: .no_toc }
 
-New firmware can be checked and installed now through druid. Make sure you have the [latest version](https://monome.org/docs/crow/druid/#update) which supports this feature.
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
 
-## Linux / Mac OS
+## Latest
+
+To check the current version of your crow inside of druid, type `^^version` into the command line.
+
+### 4.0.1
+
+*Huge thanks to all the contributors!*
+
+#### NEW
+
+- `timeline` library: [DOCS](https://monome.org/docs/crow/timeline/)  
+- `sequins`: transformers: [DOCS](https://monome.org/docs/crow/sequins2/#transformers)  
+- `sequins`: string-syntax: [DOCS](https://monome.org/docs/crow/sequins2/#sequins-strings)  
+- `hotswap` library: [DOCS](https://monome.org/docs/crow/hotswap/)  
+- seeded pseudo-random generator available as `math.srandom()`: [DOCS](https://monome.org/docs/crow/seededrandom/)  
+- support for newest hardware revision (debug led & hardware i2c pullups)  
+- extended `disting` ii interface (thanks @jroo, @ryland)  
+- method for peeking the current sequins value (thanks @tyleretters)  
+
+#### FIXED
+
+- ASL segments now correctly handle `'log'` shapes (thanks @beels)  
+- dsp samplerate was incorrect. ASL now runs at the correct speed  
+- `i2c` timing refined for more reliable transmission  
+- `i2c` driver more resilient to errors  
+- `input[n].query()` now works correctly via norns (using the `input[n].stream` event)  
+- solve "out of memory" errors when loading `ii` libraries in data-heavy scripts  
+- `input[n].scale` mode avoids double-triggers near note boundaries  
+- `ii.<module>.help()` is no longer truncated to 1024 characters  
+- `ii` address now correctly applies for up to 4 simultaneous crows on the bus  
+- `clock.sync` timing is now more accurate, and runs indefinitely  
+- changing `clock.tempo` while `clock` routines are running no longer skips events  
+- true random generator recovers when becoming insufficiently entropic  
+
+## druid
+
+New firmware can be checked and installed directly through druid. Make sure you have the [latest version of druid](https://monome.org/docs/crow/druid/#update), which supports this feature.
 
 With crow connected to your computer, open a terminal and execute:
 
@@ -22,9 +66,9 @@ You should see something like this:
 
 ```
 Checking for updates...
->> git version 2.2.0
+>> git version 3.0.1
 >> local version:  2.0.0
-Downloading new version: https://github.com/monome/crow/releases/download/v2.2.0/crow.dfu
+Downloading new version: https://github.com/monome/crow/releases/download/v3.0.1/crow.dfu
 Crow bootloader enabled.
 File: crow.dfu
     b'DfuSe' v1, image size: 304605, targets: 1
@@ -37,6 +81,10 @@ Exiting DFU...
 Update complete.
 ```
 
+### Linux / Mac OS troubleshooting
+
+#### 'command not found: druid'
+
 If you see `command not found: druid`, then please confirm that you've completed druid's [preparation](/docs/crow/druid/#preparation) and [installation](/docs/crow/druid/#install-druid).
 
 If you continue to see `command not found: druid`, there's a chance that your installation was added to your PATH under a different shell (likely either `bash` or `zsh`). You can confirm your shell by executing `echo $0` in Terminal, which will return either `-zsh` or `-bash`, depending on the current shell. To switch between them, use one of the following commands:
@@ -46,15 +94,24 @@ If you continue to see `command not found: druid`, there's a chance that your in
 
 Once you're back in the shell you used to install, you should be good to go!
 
+#### Error: No such command 'firmware'
+
 If you see `Error: No such command 'firmware'`, you first need to [update druid](/docs/crow/druid/#update).
 
-## Windows
+### Windows troubleshooting
 
-Before updating crow you'll need to install the driver for crow's bootloader, and the `libusb1` DLL file so that the PowerShell can talk to crow's bootloader.
+#### Update the Firmware
 
-*NB: If you've previously installed & used `dfu-util` you should be able to run `druid firmware` in PowerShell.*
+If you've previously installed and used `dfu-util`:
 
-### Install the WinUSB driver using Zadig
+- Open a new PowerShell as Administrator
+- Run `druid firmware` and crow will be erased and updated
+
+If you see `Error: No such command 'firmware'`, you first need to [update druid](/docs/crow/druid/#update).
+
+If you continue to run into trouble, you'll likely need to install the driver for crow's bootloader and the `libusb1` DLL file so that the PowerShell can talk to crow's bootloader. This process is outlined in the following sections. Once completed, try `druid firmware` again.
+
+#### Install the WinUSB driver using Zadig
 
 - put crow in bootloader mode: open `druid`, send `^^b` (crow will disconnect from druid), enter `q` to quit.
 - download [Zadig](https://zadig.akeo.ie)
@@ -64,24 +121,23 @@ Before updating crow you'll need to install the driver for crow's bootloader, an
 - to the right of the green arrow, you should have `WinUSB (v6.1.7600.16385)` (if you don't, please select it)
 - click the `Replace Driver` button and wait a few minutes for the process to complete
 
-### Install libusb.dll
+#### Install libusb.dll
 
 - download [libusb1.dll](https://github.com/monome/docs/blob/gh-pages/crow/libusb-1.0.zip)
 - make a folder in your user directory called `Drivers`, eg: `C:\Users\Trent\Drivers`
 - add the new `Drivers` folder to your `PATH` variable. [Instructions here](https://monome.org/docs/crow/druid/#windows-errors).
 - extract the DLL file, and place it in the folder you just created
 
-### Update the Firmware
+## norns
 
-- Open a new PowerShell as Administrator
-- Run `druid firmware` and watch your crow absorb new knowledge
+You can use the [`fledge`](https://github.com/monome/fledge) script on norns to update a connected crow to its latest firmware.
 
-If you see `Error: No such command 'firmware'`, you first need to [update druid](/docs/crow/druid/#update).
-
-## Version
-
-To check the current version inside of druid, type `^^version` into the command line.
+- connect your norns to the internet (via [WIFI](/docs/norns/wifi-files/) or ethernet)
+- open [maiden](/docs/norns/maiden)
+- execute `;install https://github.com/monome/fledge`
+- launch the `fledge` script
+- keep maiden open for progress details
 
 ## Manual Update
 
-If you have trouble, see the [manual update](/docs/crow/manual-update).
+If you have trouble with the `druid firmware` command on a non-norns computer, or wish to install a specific firmware version, see the [manual update](/docs/crow/manual-update).

--- a/modular/ii.md
+++ b/modular/ii.md
@@ -4,6 +4,15 @@ nav_exclude: true
 permalink: /modular/ii
 ---
 
+<details open markdown="block">
+  <summary>
+    sections
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
 ##  what is ii and I2C?
 
 **ii** is a flexible communication protocol which

--- a/modular/ii.md
+++ b/modular/ii.md
@@ -4,25 +4,59 @@ nav_exclude: true
 permalink: /modular/ii
 ---
 
-# ii
+##  what is ii and I2C?
 
-Various Monome Eurorack modules can communicate with each other by sending digital messages over an [I2C serial bus](https://en.wikipedia.org/wiki/I%C2%B2C), using any type of cable to connect between pin headers on the rear of each module. Using the I2C bus as a transport, many different modules now support a similar set of control messages, which together constitute the "ii" protocol. This was originally conceived as a way for [Teletype](/docs/modular/teletype) to interact with other devices, but now other devices also support initiating ii transmissions, including [Crow](/docs/crow).
+**ii** is a flexible communication protocol which
+allows modules to send commands to each other digitally, which opens up
+possibilities that patch cables can’t facilitate. This digital networking is
+described as a ‘bus’.
+
+Various monome eurorack modules can communicate with each other by sending digital messages over an [I2C serial bus](https://en.wikipedia.org/wiki/I%C2%B2C), using any type of cable to connect between pin headers on the rear of each module. Using the I2C bus as a transport, many different modules now support a similar set of control messages, which together constitute the ii protocol. This was originally conceived as a way for [Teletype](/docs/modular/teletype) to interact with other devices, but now other devices also support initiating ii transmissions, including [Crow](/docs/crow).
+
+An I2C bus consists of 3 lines - ground (GND), data (SDA) and clock (SCL).
+The data and clock lines are “pulled high” via pull-up resistors to 5V and
+data is transferred when these lines are “low”, thus power is also needed
+for the bus to operate.
+
+Both monome’s [Teletype](/docs/teletype) and [crow](/docs/crow) provide power
+over the i2c bus – however, Ansible does not. If you are in need of additional
+power or are planning to add more than three or four i2c-capable modules to your
+bus, we suggest invest in a powered bus board like the [Txb](https://store.bpcmusic.com/products/telexb).
+
+![](../images/ii_overview.png)
+
+While ii setups are usually straightforward, requiring the connection of
+matching ii headers (GND <-> GND, SCL <-> SCL, SDA <-> SDA) via 2.54mm
+connectors, there are a few consideration to keep things working:
+
+* Best practice is to daisy chain modules together. Several modules provide dual
+headers, allowing you to connect one module to the next. If your module only has
+one set of ii pins, like the [Disting Ex](https://www.expert-sleepers.co.uk/distingEX.html),
+place this at the end of the chain.
+
+* Make sure to align your ii connections correctly, with each of the corresponding
+pins. These are usually marked on the PCB – a white line is often used to refer
+to the ground pin. Note that the vertical order of the pins on each module may
+be reversed from another in your case – always check to see where the GND line is!
+
+* Keep your cables as short as possible to reduce the risk of dropped data.
+
+For additional information, please check out the helpful [i2c/ii guide](https://llllllll.co/t/a-users-guide-to-i2c/19219) available on lines.
+
+## ii tips
 
 A few quick ii tips:
 
 * Pins on each module will be labeled GND (ground), SCL (clock), and SDA (clock). These should be connected GND <-> GND, SCL <-> SCL, SDA <-> SDA,
-and you can connect them with any sort of 2.54mm pitch jumper cable. On all monome and Whimsical Raps modules, and the [TELEX expanders](https://github.com/bpcmusic/telex/),
-the pins are in this order: gnd, scl, sda. The order is the same from ground whether all pins are labeled on the board or not.
+and you can connect them with any sort of 2.54mm pitch jumper cable. On all monome and Whimsical Raps modules, and the [TELEX expanders](https://github.com/bpcmusic/telex/), the pins are in this order: gnd, scl, sda. The order is the same from ground whether all pins are labeled on the board or not.  
 Take care as other manufacturers may have different pin orderings. You won't damage anything by getting these wired wrong, but modules might crash.
 * Trilogy modules support ii, but may need a pin header soldered on. See [here](/docs/modular/iiheader).
 * I2C needs power to operate. This is achieved by "pulling up" the clock and data lines to 5V, meaning connecting an appropriate "pullup resistor" between SCL and 5V and between SDA and 5V. Some devices (generally those meant to act as leader devices) have pullup resistors wired, others (generally followers) do not -- some such as Crow make this controllable in software. The right choice of pullup value may depend on the number of devices attached, but in many cases you should probably only have one device pulling the lines up.
 * Each device on the bus has an address, which the leader uses to indicate which device it wants to talk to. Some devices support choosing between multiple addresses, others use a fixed address. Generally all followers sharing the same address will respond identically to messages sent to that address.
 
-For more technical information and help, please post on [lines](https://llllllll.co/t/a-users-guide-to-i2c/19219).
-
 ## faq
 
-While [ii](/docs/modular/ii) setups with a few devices are usually
+While ii setups with a few devices are usually
 straightforward (e.g., connect headers between Teletype and Just
 Friends - done!), as networks involve more modules there can be some
 important considerations to keep things working. Here are some common


### PR DESCRIPTION
general cleanup of the crow docs, ahead of 4.0's release. mostly formatting + page layout, but also changed a few content bits:

- the norns study now has no mention of `ii.pullup`
- the script reference now has default values listed where applicable
- rearranged `update.md` and added 4.0.1 changelog (@trentgill , unsure if what's posted at https://github.com/monome/crow/releases/tag/v4.0.1 is complete or if you wanna massage it, but figured it was fine as a placeholder!)