### PR TITLE
fix broken norns.community link

### DIFF
--- a/crow/index.md
+++ b/crow/index.md
@@ -36,7 +36,7 @@ If you would like to use the [ii](/docs/modular/ii) functionality, be sure to ob
 
 ### norns
 
-crow integrates seamlessly with norns as a CV and [ii](/docs/modular/ii) interface. By default, crow can be a norns clocking source or destination. [Many scripts have additional crow functionality](https://norns.community/t/crow).
+crow integrates seamlessly with norns as a CV and [ii](/docs/modular/ii) interface. By default, crow can be a norns clocking source or destination. [Many scripts have additional crow functionality](https://norns.community/tag/crow).
 
 Want to script on your own? See the full [crow studies](norns) for a complete guide
 


### PR DESCRIPTION
cc @dndrks ! 

guessing this link got broken in the migration to the new norns.community site? 

the change on the last line was automatic by the github web editor - is it just a newline or something? edit at will :) 