### PR TITLE
serialosc docs cleanup

### DIFF
--- a/serialosc/index.md
+++ b/serialosc/index.md
@@ -27,7 +27,7 @@ The rest of this document details what these pre-made libraries abstract, for th
 
 `serialoscd` keeps watch for connection and disconnection of devices. When connected, a new process is launched 'serialosc-device' which communicates on its own port.
 
-We will assume a theoretical application on port 66666 on localhost is trying to connect to serialosc. We'll also assume you have `liblo` installed, which includes `oscsend` and `oscdump`.
+We will assume a theoretical application on port 6666 on localhost is trying to connect to serialosc. We'll also assume you have `liblo` installed, which includes `oscsend` and `oscdump`.
 
 First, connect your grid to your computer. Then, open a terminal window and set up an OSC monitor:
 
@@ -56,7 +56,9 @@ Now when keys on the grid are pressed we should see something like:
 
 - `oscsend localhost 17675 /sys/prefix s "/blinky"`
 
-Note that when a grid is disconnected + reconnected, its prefix will return to `/monome`.
+Note that this prefix is saved in your computer's [serialosc preferences](#serialosc-preferences) so that when this grid is disconnected + reconnected, its prefix will remain the defined value. To your grid's prefix change back to default:
+
+- `oscsend localhost 17675 /sys/prefix s "/monome"`
 
 To send LED data:
 
@@ -66,3 +68,32 @@ To send LED data:
 See [OSC](/docs/serialosc/osc) for the complete list of messages.
 
 All ports are also discoverable via zeroconf as `_monome-osc._udp`.
+
+### Preferences
+
+`serialoscd` will save a preference file for each monome device connected to your computer, where prefixes and other information about your device are stored long-term.
+
+The filepath to this folder varies depending on your operating system:
+
+- Linux: `$XDG_CONFIG_HOME/serialosc` or `$HOME/.config/serialosc`
+- macOS: `~/Library/Preferences/org.monome.serialosc`
+- Windows: `$APPDATA\\Monome\\serialosc`
+
+Inside this folder, you see `.conf` files with each device's serial number (eg. `m93274581.conf`), wherein you'll find the device's persistent settings:
+
+```bash
+server {
+  port = 17218
+}
+application {
+  osc_prefix = "/monome"
+  host = "127.0.0.1"
+  port = 7778
+}
+device {
+  rotation = 0
+}
+
+```
+
+If you ever need to start fresh, you can simply delete the corresponding `.conf` file and `serialoscd` will generate a new profile using the default settings.

--- a/serialosc/index.md
+++ b/serialosc/index.md
@@ -27,33 +27,41 @@ The rest of this document details what these pre-made libraries abstract, for th
 
 `serialoscd` keeps watch for connection and disconnection of devices. When connected, a new process is launched 'serialosc-device' which communicates on its own port.
 
-We will assume a theoretical application on port 66666 on localhost is trying to connect to serialosc.
+We will assume a theoretical application on port 66666 on localhost is trying to connect to serialosc. We'll also assume you have `liblo` installed, which includes `oscsend` and `oscdump`.
 
-To list the available devices, query `serialoscd` which listens on port 12002:
+First, connect your grid to your computer. Then, open a terminal window and set up an OSC monitor:
 
-- to port 12002: `/serialosc/list localhost 66666`
+- `oscdump 6666`
+
+Open another terminal window. To list the available devices, we'll query `serialoscd` which listens on port 12002, and we'll route the response to our monitor:
+
+- `oscsend localhost 12002 /serialosc/list si localhost 6666`
 
 Say we have an 8x16 grid attached, results might look like this:
 
-- received on port 66666: /serialosc/device "m1000000" "monome 128" 21008
+- `e83daeee.d2ea63b5 /serialosc/device ssi "m46674021" "monome 128" 17675`
 
-Here, port 21008 is where the device is listening. To have this grid send to our application:
+Here, port 17675 is where the device is listening. To have this grid send to our application:
 
-- to port 21008: `/sys/port 66666`
+- `oscsend localhost 17675 /sys/port i 6666`
 
 Now when keys on the grid are pressed we should see something like:
 
 ```
-/grid/key 0 0 1
-/grid/key 0 2 1
+<timestamp> /monome/grid/key iii 9 3 1
+<timestamp> /monome/grid/key iii 9 3 0
 ```
 
-...which follow the form `/prefix/key x y z`. Note, the "prefix" is changeable with a message.
+...which follow the form `/prefix/grid/key x y z`. Note, that while the "prefix" defaults to `/monome`, it's changeable with any string. For example, to change our prefix to `/blinky`:
+
+- `oscsend localhost 17675 /sys/prefix s "/blinky"`
+
+Note that when a grid is disconnected + reconnected, its prefix will return to `/monome`.
 
 To send LED data:
 
-- to port 21008: `/grid/led/all 0` (clear the grid)
-- to port 21008: `/grid/led/level/set 2 2 8 (set LED 2,2 to brightness 8)
+- `oscsend localhost 17675 /monome/grid/led/level/set iii 2 2 8` (set LED 2,2 to brightness 8)
+- `oscsend localhost 17675 /monome/grid/led/all i 0` (clear the grid)
 
 See [OSC](/docs/serialosc/osc) for the complete list of messages.
 

--- a/serialosc/osc.md
+++ b/serialosc/osc.md
@@ -17,6 +17,8 @@ The serialosc server listens on port 12002.
 
 When devices are connected, serialosc spawns new ports for each device. querying the server allows you to discover the port number for each device.
 
+Note that all of the messages listed in this section have argument types included, eg. `si` or `iiii`. These are **not** needed for top-level environments like Max/MSP, SuperCollider, and many others. We included them here to reflect lower-level use with `oscsend` and `oscdump`.
+
 ### messages sent to serialosc server
 
 | message                              | description                                                                                                                                                                        |

--- a/serialosc/osc.md
+++ b/serialosc/osc.md
@@ -90,11 +90,11 @@ The messages below are sent after a `/sys/info` request is received:
 
 ### grid
 
-| message                                | description                                      |
-| -------------------------------------- | ------------------------------------------------ |
-| `/grid/led/set x y s`                  | Set led at (x,y) to state s (0 or 1)             |
-| `/grid/led/all s`                      | Set all leds to state s (0 or 1)                 |
-| `/grid/led/map x_offset y_offset s[8]` | Set a quad (8×8, 64 buttons) in a single message |
+| message                                                         | description                                      |
+| --------------------------------------------------------------- | ------------------------------------------------ |
+| `<prefix>/grid/led/set iii <x> <y> <s>`                         | Set led at (x,y) to state s (0 or 1)             |
+| `<prefix>/grid/led/all i <s>`                                   | Set all leds to state s (0 or 1)                 |
+| `<prefix>/grid/led/map iiiiiiiiii <x_offset> <y_offset> <s[8]>` | Set a quad (8×8, 64 buttons) in a single message |
 
 #### map
 
@@ -102,21 +102,21 @@ Each number in the `map` list is a bitmask of the buttons in a row, one number i
 
 Taken apart:
 
-    (/grid/led/map)  <- the message/route
+    (<prefix>/grid/led/map)  <- the message/route
                    (8 8)  <- the offsets (must be multiples of 8)
                         (1 2 4 8 16 32 64 128)  <- the bitmasks for each row
 
 _examples_
 
 ```
-/grid/led/map 0 0 4 4 4 4 8 8 8 8
-/grid/led/map 0 0 254 253 125 247 239 36 191 4
+<prefix>/grid/led/map iiiiiiiiii 0 0 4 4 4 4 8 8 8 8
+<prefix>/grid/led/map iiiiiiiiii 0 0 254 253 125 247 239 36 191 4
 ```
 
 #### row
 
 ```
-/grid/led/row x_offset y s[..]
+<prefix>/grid/led/row x_offset ii.. <y> <s[..]>
 ```
 
 Set a row in a quad in a single message. Offsets must be multiples of 8. Note that offsets for 64-sized grids should always be 0.
@@ -126,21 +126,21 @@ Each number in the list is a bitmask of the buttons in a row, one number in the 
 _examples (for 256)_
 
 ```
-/grid/led/row 0 0 255 255
-/grid/led/row 8 5 255
+<prefix>/grid/led/row iiii 0 0 255 255
+<prefix>/grid/led/row iii 8 5 255
 ```
 
 _examples (for 64)_
 
 ```
-/grid/led/row 0 0 232
-/grid/led/row 0 3 129
+<prefix>/grid/led/row iii 0 0 232
+<prefix>/grid/led/row iii 0 3 129
 ```
 
 #### col
 
 ```
-/grid/led/col x y_offset s[..]
+<prefix>/grid/led/col iii[..] <x> <y_offset> <s[..]>
 ```
 
 Set a column in a quad in a single message. Offsets must be multiples of 8. Note that offsets for 64-sized grids should always be 0
@@ -150,22 +150,22 @@ Each number in the list is a bitmask of the buttons in a column, one number in t
 _examples (for 256)_
 
 ```
-/grid/led/col 0 0 255 255 (updates quads 1 and 3)
-/grid/led/col 13 8 255 (updates quad 4 due to offset.)
+<prefix>/grid/led/col iiii 0 0 255 255 (updates quads 1 and 3)
+<prefix>/grid/led/col iii 13 8 255 (updates quad 4 due to offset)
 ```
 
 _examples (for 64)_
 
 ```
-/grid/led/col 0 0 232
-/grid/led/col 6 0 155
+<prefix>/grid/led/col iii 0 0 232
+<prefix>/grid/led/col iii 6 0 155
 ```
 
 #### variable brightness
 
-Valid values for 'l' below are in the range [0, 15].
+Valid values for `<l>` below are in the range [0, 15].
 
-January 2011 devices only support four intensity levels (off + 3 brightness levels). The value passed in /level/ messages will be “rounded down” to the lowest available intensity as below:
+January 2011 devices only support four intensity levels (off + 3 brightness levels). The value passed in `/level/` messages will be “rounded down” to the lowest available intensity as below:
 
 - [0, 3] - off
 - [4, 7] - low intensity
@@ -175,17 +175,17 @@ January 2011 devices only support four intensity levels (off + 3 brightness leve
 Devices from June 2012 (and after) allow all 16 intensity levels.
 
 ```
-/grid/led/level/set x y l
-/grid/led/level/all l
-/grid/led/level/map x_off y_off l[64]
-/grid/led/level/row x_off y l[..]
-/grid/led/level/col x y_off l[..]
-/grid/led/intensity i
+<prefix>/grid/led/level/set iii <x> <y> <l>
+<prefix>/grid/led/level/all i <l>
+<prefix>/grid/led/level/map iii[64] <x_off> <y_off> <l[64]>
+<prefix>/grid/led/level/row iii[..] <x_off> <y> <l[..]>
+<prefix>/grid/led/level/col iii[..] <x> <y_off> <l[..]>
+<prefix>/grid/led/intensity i <l>
 ```
 
 #### tilt
 
-    /tilt/set n s
+    <prefix>/tilt/set ii <n> <s>
 
 Set active state of tilt sensor n to s (0 or 1, 1 = active, 0 = inactive).
 
@@ -193,33 +193,33 @@ Set active state of tilt sensor n to s (0 or 1, 1 = active, 0 = inactive).
 
 Note that LED 0 is north. LED numbers increase clockwise.
 
-| message                 | description                                                                                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/ring/set n x l`       | Set LED `x` (0-63) on encoder `n` (0-1 or 0-3) to level `l` (0-15)                                                                               |
-| `/ring/all n l`         | Set all LEDs on encoder `n` (0-1 or 0-3) to level `l` (0-15)                                                                                     |
-| `/ring/map n l[64]`     | Set all LEDs on encoder `n` (0-1 or 0-3) to 64 member array `l[64]`                                                                              |
-| `/ring/range n x1 x2 l` | Set LEDs on encoder `n` (0-1 or 0-3) between (inclusive) `x1` and `x2` to level `l` (0-15). Direction of set is always clockwise, with wrapping. |
+| message                                      | description                                                                                                                                      |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<prefix>/ring/set iii <n> <x> <l>`          | Set LED `x` (0-63) on encoder `n` (0-1 or 0-3) to level `l` (0-15)                                                                               |
+| `<prefix>/ring/all ii <n> <l>`               | Set all LEDs on encoder `n` (0-1 or 0-3) to level `l` (0-15)                                                                                     |
+| `<prefix>/ring/map ii[64] <n> <l[64]>`       | Set all LEDs on encoder `n` (0-1 or 0-3) to 64 member array `l[64]`                                                                              |
+| `<prefix>/ring/range iiii <n> <x1> <x2> <l>` | Set LEDs on encoder `n` (0-1 or 0-3) between (inclusive) `x1` and `x2` to level `l` (0-15). Direction of set is always clockwise, with wrapping. |
 
 ## from device
 
 ### grid
 
-    /grid/key x y s
+    <prefix>/grid/key iii x y s
 
 Key state change at (`x`,`y`) to `s` (0 or 1, 1 = key down, 0 = key up).
 
 ### tilt
 
-    /tilt n x y z
+    <prefix>/tilt iiii n x y z
 
 Position change on tilt sensor `n`, integer (8-bit) values (`x`, `y`, `z`).
 
 ### arc
 
-    /enc/delta n d
+    <prefix>/enc/delta ii n d
 
 Position change on encoder `n` by value `d` (signed). Clockwise is positive.
 
-    /enc/key n s
+    <prefix>/enc/key ii n s
 
 Key state change on encoder `n` to `s` (0 or 1, 1 = key down, 0 = key up).

--- a/serialosc/serial.txt
+++ b/serialosc/serial.txt
@@ -22,7 +22,7 @@ serial:		[0x05]
 
 // led-grid
 
-pattern:	/prefix/led/set x y s
+pattern:	/prefix/grid/led/set x y s
 desc:		set led state
 args:		x = x value (0-255)
 			y = y value (0-255)
@@ -30,20 +30,20 @@ args:		x = x value (0-255)
 serial:		if s = 0, [0x10, x, y]
 			if s = 1, [0x11, x, y]
 
-pattern:	/prefix/led/all s
+pattern:	/prefix/grid/led/all s
 desc:		set all leds
 args:		s = on/off (0-1)
 serial:		if s = 0, [0x12]
 			if s = 1, [0x13]
 
-pattern:	/prefix/led/map x y d[8]
+pattern:	/prefix/grid/led/map x y d[8]
 desc:		set 8x8 block of leds, with offset
 args:		x = x offset, will be floored to multiple of 8 by firmware
 			y = y offset, will be floored to multiple of 8 by firmware
 			d[8] = bitwise display data
 serial:		[0x14, x, y, d[8]]
 
-pattern:	/prefix/led/row x y d
+pattern:	/prefix/grid/led/row x y d
 desc:		set 8x1 block of leds, with offset
 args:		x = x offset, will be floored to multiple of 8 by firmware
 			y = y offset
@@ -51,7 +51,7 @@ args:		x = x offset, will be floored to multiple of 8 by firmware
 serial:		[0x15, x, y, d]
 note:		d can be an array. for each additional element, another serial packet is sent, with x offset incremented by 8.
 
-pattern:	/prefix/led/col x y d
+pattern:	/prefix/grid/led/col x y d
 desc:		set 1x8 block of leds, with offset
 args:		x = x offset
 			y = y offset, will be floored to multiple of 8 by firmware
@@ -59,24 +59,24 @@ args:		x = x offset
 serial:		[0x16 x, y, d]
 note:		d can be an array. for each additional element, another serial packet is sent, with y offset incremented by 8.
 
-pattern:	/prefix/led/intensity i
+pattern:	/prefix/grid/led/intensity i
 desc:		set intensity for entire grid
 args:		i = intensity (0-15)
 serial:		[0x17, i]
 
-pattern:	/prefix/led/level/set x y i
+pattern:	/prefix/grid/led/level/set x y i
 desc:		set led intensity
 args:		x = x value (0-255)
 			y = y value (0-255)
 			i = intensity (0-255)
 serial:		[0x18, x, y, i]
 
-pattern:	/prefix/led/level/all s
+pattern:	/prefix/grid/led/level/all s
 desc:		set all leds to level
 args:		i = intensity (0-255)
 serial:		[0x19, i]
 
-pattern:	/prefix/led/level/map x y d[32]
+pattern:	/prefix/grid/led/level/map x y d[32]
 desc:		set 8x8 block of leds levels, with offset
 args:		x = x offset, will be floored to multiple of 8 by firmware
 			y = y offset, will be floored to multiple of 8 by firmware
@@ -89,7 +89,7 @@ args:		x = x offset, will be floored to multiple of 8 by firmware
 			d[31] (4:7) value 63
 serial:		[0x1A, x, y, d[32]]
 
-pattern:	/prefix/led/level/row x y d[8]
+pattern:	/prefix/grid/led/level/row x y d[8]
 desc:		set 8x1 block of led levels, with offset
 args:		x = x offset, will be floored to multiple of 8 by firmware
 			y = y offset
@@ -97,7 +97,7 @@ args:		x = x offset, will be floored to multiple of 8 by firmware
 serial:		[0x1B, x, y, d[8]]
 note:		if d[8] has more than 8 elements (multiple of 8) send multiple serial packets with proper offset
 
-pattern:	/prefix/led/level/col x y d[8]
+pattern:	/prefix/grid/led/level/col x y d[8]
 desc:		set 1x8 block of led levels, with offset
 args:		x = x offset
 			y = y offset, will be floored to multiple of 8 by firmware
@@ -167,7 +167,7 @@ args:		x = x size
 
 // key
 
-pattern:	/prefix/key x y s
+pattern:	/prefix/grid/key x y s
 desc:		key state change
 serial:		if s = 0 [0x00, x, y] key up
 			if s = 1 [0x01, x, y] key down
@@ -379,17 +379,17 @@ to device:
 ----------
 
 OSC:
-/led/set x y [0/1]
+/grid/led/set x y [0/1]
 	mapped to 0x10 and 0x11
-/led/all [0/1]
+/grid/led/all [0/1]
 	mapped to 0x12 and 0x13
-/led/map x y d[8]
+/grid/led/map x y d[8]
 	mapped to 0x14
-/led/row x y d
+/grid/led/row x y d
 	mapped to 0x15
-/led/col x y d
+/grid/led/col x y d
 	mapped to 0x16
-/led/intensity x
+/grid/led/intensity x
 	mapped to 0x17
 
 0x10 led-grid / led off
@@ -503,7 +503,7 @@ from device:
 ------------
 
 OSC:
-/key x y [0/1]
+/grid/key x y [0/1]
 	mapped to 0x20 and 0x21
 
 0x20 key-grid / key up


### PR DESCRIPTION
based on recent conversations with @ryleelyman and @tehn!

this PR addresses a few points in the serialosc docs:

- `serial.txt` didn't have the correct formatting for grid messages. eg. i changed `/prefix/led/set x y s` to `/prefix/grid/led/set x y s`
- the introductory walkthrough in the serialosc landing page required more familiarity than a 'first timer' might be able to grok, so i added some `oscsend` and `oscdump` formatting to each of the code examples
- the `osc.md` serialosc reference was missing `<prefix>` callouts and argument manifests (eg. `iii`), which are required for successful communication

@tehn , please lmk if any of this is too heavy handed for your tastes and i can scale back!
@ryleelyman, did you run into any other docs stumbling blocks during your seamstress development?