### PR TITLE
Documentation to start on boot as a user on desktop Linux

### DIFF
--- a/serialosc/linux.md
+++ b/serialosc/linux.md
@@ -26,9 +26,9 @@ If there are no precompiled packages available for your distribution, you can st
 
 - [compiling from source](/docs/serialosc/source)
 
-## Running at Boot
+### Running at Boot
 
-Add the following systemd unit to `.config/systemd/user/serialoscd.service` 
+If you are compiling from source and would like the service to start automatically, add the following systemd unit to `.config/systemd/user/serialoscd.service` 
 
 ```
 [Unit]
@@ -45,6 +45,8 @@ Reload systemd with `sudo systemctl daemon-reload`
 Install to a different path? Change the above to match your preference. You can enable serialoscd to start at boot by running `systemctl --user enable serialoscd.service` which will start the daemon at each login.
 
 To manually start and stop, this works like any other systemd unit, for example to start manually `systemctl --user start serialoscd.service` will do.
+
+This is not needed if you install the binary package.
 
 ## Notes
 

--- a/serialosc/linux.md
+++ b/serialosc/linux.md
@@ -26,6 +26,26 @@ If there are no precompiled packages available for your distribution, you can st
 
 - [compiling from source](/docs/serialosc/source)
 
+## Running at Boot
+
+Add the following systemd unit to `.config/systemd/user/serialoscd.service` 
+
+```
+[Unit]
+Description=Starts serialoscd at system boot
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/serialoscd
+
+```
+
+Reload systemd with `sudo systemctl daemon-reload`
+
+Install to a different path? Change the above to match your preference. You can enable serialoscd to start at boot by running `systemctl --user enable serialoscd.service` which will start the daemon at each login.
+
+To manually start and stop, this works like any other systemd unit, for example to start manually `systemctl --user start serialoscd.service` will do.
+
 ## Notes
 
 You'll need to have the `usbserial` and `ftdi_sio` kernel modules loaded before connecting your grid. Most Linux distributions include these modules by default, and should load them as soon as they detect your grid being plugged in. If these USB and serial modules are not available in your kernel, follow your distribution's documentation for configuring, compiling, and installing a custom kernel.


### PR DESCRIPTION
Adds text for a preference to enable the daemon at boot/login through systemd. It includes notes to manually start the service via systemd.

@artfwo here u go!