### PR TITLE
norns: Clarify use of mod hooks

### DIFF
--- a/norns/mods.md
+++ b/norns/mods.md
@@ -37,6 +37,8 @@ five hooks:
 * `script_post_cleanup` - called after a script's `cleanup()` function has been
   called, this normally occurs when switching between scripts
 
+Notice that the hooks are for events that happen outside any mods - around the system's startup and shutdown, and around any scripts loading and unloading. So by registering functions with the hooks mods can interact with those things.
+
 Multiple mods can each register their own callback function for a given hook.
 matron will sort the hooks alphabetically before executing them. This allows mods that add parameters to add them in a consistent order -- eg. mods that need all parameters available before executing should start with `~` to ensure they're at the end.
 


### PR DESCRIPTION
This paragraph emphasises what mods' hooks do, and how they're useful. I've added it because I failed to understand these points, and I hope it will help others avoid the same mistake.

In a bit more detail: Strictly speaking this paragraph shouldn't be necessary - all the information is already there on the page. But despite reading it several times I failed to understand these key points. For example, I didn't realise that the `script_...` hooks really do relate to user scripts and not the mod (which in my mind is just a different kind of script). And I didn't understand why some events were captured in hooks and other events (specifically `init()` and `deinit()`) were not. I think this additional text makes it clearer.