### PR TITLE
Update Docker for late 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
@@ -6,8 +6,8 @@ ENV LANGUAGE en_US.UTF-8
 
 WORKDIR /usr/src/app
 
-COPY Gemfile just-the-docs.gemspec ./
-RUN gem install bundler && bundle install
+COPY Gemfile ./
+RUN gem install bundler -v 2.4.22 && bundle install
 
 EXPOSE 4000
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ http://monome.org/docs
 
 contributions welcome.
 
+## developing with Docker
+
+run:
+
+```bash
+git clone https://github.com/monome/docs
+cd docs/
+docker compose up
+```
+
+then go to [http://localhost:4000/docs/](http://localhost:4000/docs/) to view the site.
+
 ## developing locally
 
 it is recommended to install [rvm](https://rvm.io/rvm/install) and us ruby 2.7.2.


### PR DESCRIPTION
Using `docker compose` is cleaner and easier than a new Ruby environment on bare metal. So the README now recommends it. But the existing Dockerfile wouldn't run anymore, so it got updated.