### PR TITLE
Add reference to `arc.key(n, z)`

### DIFF
--- a/arc/index.md
+++ b/arc/index.md
@@ -41,11 +41,6 @@ Most use cases (computers with serialosc, norns, ansible) require the arc to be 
 * [pear](https://llllllll.co/t/32699) -- dual manual tape player
 * [arc4live](https://github.com/robbielyman/arc4live/tree/main) -- simplified arc-as-four-knobs Max for Live patch featuring trimmers on modulation range
 * more patches can be found at the library of [llllllll.co](https://llllllll.co/tag/max), the [monome-community github](https://github.com/orgs/monome-community/) and the [collected repository](https://github.com/monome-community/collected)
- 
-### studies
-
-- [norns](/docs/norns/study-4b) -- monome's sound computer
-- [SuperCollider](/docs/arc/studies/sc) -- synthesis engine and programming environment
 
 monome libraries for other environments:
 
@@ -55,6 +50,11 @@ monome libraries for other environments:
 * [monome-processing](https://github.com/monome/monome-processing) -- Processing
 * [monomeSC](https://github.com/monome/monomeSC/) -- SuperCollider
 * [pymonome](https://github.com/artfwo/pymonome) -- Python
+
+### studies
+
+- [norns](/docs/norns/study-4b) -- monome's sound computer (see below)
+- [SuperCollider](/docs/arc/studies/sc) -- synthesis engine and programming environment
 
 Note: the [grid studies](https://monome.org/docs/grid/grid-computer/#studies) broadly apply to arc but the OSC patterns differ.
 
@@ -78,6 +78,10 @@ Selection of community contributed scripts that support arc:
 - [arcify](https://llllllll.co/t/arcify/22133): map arc to norns parameters
 - [easygrain](https://llllllll.co/t/easygrain/21047): granulator with arc support
 - [larc](https://llllllll.co/t/larc/39790): three play-heads, one rec-head
+- [awake](https://llllllll.co/t/awake/21022): one sequence transposed by another
+- [euclidigons](https://llllllll.co/t/euclidigons/36666/): polygons collide, make sounds
+
+Reference API docs for Arc on Norns can be found [here](/docs/norns/reference/arc).
 
 ## with modular
 

--- a/norns/reference.md
+++ b/norns/reference.md
@@ -265,7 +265,7 @@ include("otherscript/lib/otherlib")
 
 ### engine
 
-Specify an engine at the top of your script. See the [engine docs](https://monome.org/docs/norns/api/modules/engine.html) for more details.
+Specify an engine at the top of your script. See the [engine docs](/docs/norns/api/modules/engine.html) for more details.
 
 ```lua
 engine.name = 'PolySub'
@@ -296,7 +296,7 @@ tab.print(engine.names)
 
 ### screen
 
-The screen API handles drawing on the norns screen. See the [screen docs](https://monome.org/docs/norns/api/modules/screen.html) for more details.
+The screen API handles drawing on the norns screen. See the [screen docs](/docs/norns/api/modules/screen.html) for more details.
 
 ```lua
 function redraw()
@@ -309,7 +309,7 @@ end
 
 ### metro
 
-The metro API allows for high-resolution scheduling. See the [metro docs](https://monome.org/docs/norns/api/modules/metro.html) for more details.
+The metro API allows for high-resolution scheduling. See the [metro docs](/docs/norns/api/modules/metro.html) for more details.
 
 ```lua
 re = metro.init()
@@ -324,7 +324,7 @@ end
 
 ### paramset
 
-The paramset API allows to read and write temporary data and files. See the [paramset docs](https://monome.org/docs/norns/api/modules/paramset.html) for more details.
+The paramset API allows to read and write temporary data and files. See the [paramset docs](/docs/norns/api/modules/paramset.html) for more details.
 
 A parameter can be installed with the following:
 
@@ -366,7 +366,7 @@ params, paramset, paths, poll, redraw, screen, softcut, string, tab, util, wifi
 
 ### grid
 
-`grid.connect(n)` to create device, returns object with handler. See the [grid docs](https://monome.org/docs/norns/api/modules/grid.html) for more details.
+`grid.connect(n)` to create device, returns object with handler. See the [grid docs](/docs/norns/api/modules/grid.html) for more details.
 
 ```lua
 g = grid.connect()
@@ -379,7 +379,7 @@ g = grid.connect()
 
 ### arc
 
-`arc.connect(n)` to create device, returns object with handler. See the [arc docs](https://monome.org/docs/norns/api/modules/arc.html) for more details.
+`arc.connect(n)` to create device, returns object with handler. See the [arc docs](/docs/norns/api/modules/arc.html) for more details.
 
 ```lua
 a = arc.connect()
@@ -390,10 +390,11 @@ a = arc.connect()
 - `a:segment(ring, from, to, level)`, creates an anti-aliased point to point arc - segment/range on a specific LED ring.
 - `a:refresh()`, updates any dirty quads on this arc device.
 - `a.delta(n, delta)`, encoder event handler function.
+- `a.key(n, z)`, key (pushbutton) event handler function.
 
 ### midi
 
-`midi.connect(n)` to create device, returns object with handler. See the [midi docs](https://monome.org/docs/norns/api/modules/midi.html) for more details.
+`midi.connect(n)` to create device, returns object with handler. See the [midi docs](/docs/norns/api/modules/midi.html) for more details.
 
 ```lua
 m = midi.connect()
@@ -405,7 +406,7 @@ m = midi.connect()
 
 ### hid
 
-`hid.connect(n)` to create device, returns object with handler. See the [hid docs](https://monome.org/docs/norns/api/modules/hid.html) for more details.
+`hid.connect(n)` to create device, returns object with handler. See the [hid docs](/docs/norns/api/modules/hid.html) for more details.
 
 ```lua
 h = hid.connect()
@@ -413,7 +414,7 @@ h = hid.connect()
 
 ### osc
 
-Send networked data via Open Sound Control. See the [osc docs](https://monome.org/docs/norns/api/modules/osc.html) for more details.
+Send networked data via Open Sound Control. See the [osc docs](/docs/norns/api/modules/osc.html) for more details.
 
 - `osc.send(to, path, args)`, sends osc event.
 - `osc.event(path, args, from)` handler function called when an osc event is received.

--- a/norns/reference/arc.md
+++ b/norns/reference/arc.md
@@ -19,6 +19,7 @@ has_children: false
 | my_arc:segment(ring, from, to, val) | Create an anti-aliased point to point arc segment/range on a specific ring of this connected arc, 'from' and 'to' expect radians |
 | my_arc:refresh()                    | Update any dirty LEDs on this connected arc                                                                                      |
 | my_arc.delta(n, delta)              | Pass encoder delta events to a script : function                                                                                 |
+| my_arc.key(n, z)                    | Pass key events to a script (Arc 2025 has a single pushbutton, n=1) : function                                                   |
 | arc.add()                           | User script callback when any arc is connected                                                                                   |
 | arc.remove()                        | User script callback when any arc is disconnected                                                                                |
 


### PR DESCRIPTION
This is for Arc 2025. Previously, this was only mentioned in a study, not in the reference. I don't know how the actual raw API docs are generated, so I didn't update those pages (i.e. norns/api/modules/arc.html).

I also added mentions of more user scripts, cross-referenced things a bit, and made a few links relative to the current domain so when you click around when doing local edits to the docs, you're not sent away to monome.org.