### PR TITLE
Fix PuTTY download link in advanced-access.md

### DIFF
--- a/norns/advanced-access.md
+++ b/norns/advanced-access.md
@@ -191,7 +191,7 @@ You'll be asked for login credentials. Login is the same as SSH above.
 - open *Device Manager* and navigate to your computer's *Ports (COM & LPT)*
 - confirm the *COM* ID that your computer has assigned the *USB Serial Port*. For example, this norns is assigned `COM14`:
   ![](/docs/norns/image/advanced_access-images/device-manager.png)
-- [download PuTTY](https://www.putty.org), a free and open-source SSH client for Windows
+- [download PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html), a free and open-source SSH client for Windows
 - in PuTTY's *Session* Category, choose *Connection type: Serial* and replace the *Serial line* with your COM ID.
   - NOTE: do not choose the *Connection > Serial* menu! This process only works through the *Session* menu at the top of the list. For a visual, see below.
 - replace *Speed* with `115200`


### PR DESCRIPTION
Updates the link for downloading PuTTY. The current link goes to a site that says:

> Looking for PuTTY, the software? [It's here.](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html)
>
> This page is unaffiliated with the PuTTY project, and is not endorsed by it.
The PuTTY project or its authors have never owned this domain, registered it, or purchased it.
The domain was originally registered in 1999, for purposes unrelated to software.